### PR TITLE
Build a dockerfile upon releasing and publish it to the github registry

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,20 @@
+on:
+  release:
+    types:
+      - published
+
+name: Docker build
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        submodules: true
+      - uses: elgohr/Publish-Docker-Github-Action@v5
+        with:
+          name: "${{ env.GITHUB_REPOSITORY }}/tyler"
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: ghcr.io
+          dockerfile: docker/tyler.dockerfile
+          tag_semver: true


### PR DESCRIPTION
Fixes https://github.com/3DGI/tyler/issues/18

In this change, I have introduced a github action file that builds and publishes a docker image to the Github registry. I have used the action from https://github.com/elgohr/Publish-Docker-Github-Action to do so, and set it to only build a docker image upon publishing a github release. The tags will follow semver, thus if a release is tagged with v1.2.3; it will create tag 1, 1.2 and 1.2.3.

Unfortunately, I have not been able to test this specific config because it only triggers upon publishing a release; it is based on the publishing flow in phpDocumentor (https://github.com/phpDocumentor/phpDocumentor/actions/runs/5451013134/workflow) but with tweaks for semver and for the alternate dockerfile location.