### PR TITLE
Smooth normals

### DIFF
--- a/cityjson-convert/src/gltf_writer.rs
+++ b/cityjson-convert/src/gltf_writer.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::too_many_lines)]
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::convert::TryFrom;
 use std::fs::File;
 use std::io::Write;
@@ -91,8 +91,11 @@ pub fn write_city_model_glb<P: AsRef<Path>>(
     options: &ExportOptions,
 ) -> Result<()> {
     let coordinate_transform = CoordinateTransform::from_model(model, options)?;
-    let mut collector =
-        MeshCollector::with_lod_filter(options.feature_type_lods.clone(), coordinate_transform);
+    let mut collector = MeshCollector::with_lod_filter(
+        options.feature_type_lods.clone(),
+        coordinate_transform,
+        options.smooth_normals,
+    );
     collector.add_model(model)?;
     let processed = collector.finish()?;
     info!(
@@ -324,12 +327,19 @@ struct MeshCollector {
     primitives: BTreeMap<String, RawPrimitiveMesh>,
     feature_type_lods: BTreeMap<String, String>,
     coordinate_transform: CoordinateTransform,
+    smooth_normals: bool,
 }
 
 struct CoordinateTransform {
     vertex_transformer: Option<Proj>,
     storage_origin: [f64; 3],
     node_translation_base: [f32; 3],
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+struct SmoothVertexKey {
+    position_bits: [u32; 3],
+    feature_id: u32,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -448,6 +458,15 @@ struct QuantizedScene {
     position_scale: f32,
     center: [f32; 3],
     features: Vec<FeatureRecord>,
+}
+
+impl SmoothVertexKey {
+    fn new(position: [f32; 3], feature_id: u32) -> Self {
+        Self {
+            position_bits: position.map(f32::to_bits),
+            feature_id,
+        }
+    }
 }
 
 impl CoordinateTransform {
@@ -614,12 +633,14 @@ impl MeshCollector {
     fn with_lod_filter(
         feature_type_lods: BTreeMap<String, String>,
         coordinate_transform: CoordinateTransform,
+        smooth_normals: bool,
     ) -> Self {
         Self {
             features: Vec::new(),
             primitives: BTreeMap::new(),
             feature_type_lods,
             coordinate_transform,
+            smooth_normals,
         }
     }
 
@@ -764,15 +785,22 @@ impl MeshCollector {
             return Ok(());
         }
 
-        self.primitives
-            .entry(feature_type.to_string())
-            .or_default()
-            .emit_triangles(
+        let primitive = self.primitives.entry(feature_type.to_string()).or_default();
+        if self.smooth_normals {
+            primitive.emit_triangles_smooth(
                 feature_id,
                 &local_positions,
                 &triangulated,
                 Self::compute_face_normal,
             )
+        } else {
+            primitive.emit_triangles_flat(
+                feature_id,
+                &local_positions,
+                &triangulated,
+                Self::compute_face_normal,
+            )
+        }
     }
 
     fn collect_feature_attributes(
@@ -910,7 +938,7 @@ impl MeshCollector {
 }
 
 impl RawPrimitiveMesh {
-    fn emit_triangles<F>(
+    fn emit_triangles_flat<F>(
         &mut self,
         feature_id: u32,
         positions: &[[f32; 3]],
@@ -948,6 +976,82 @@ impl RawPrimitiveMesh {
         }
 
         Ok(())
+    }
+
+    fn emit_triangles_smooth<F>(
+        &mut self,
+        feature_id: u32,
+        positions: &[[f32; 3]],
+        triangulated: &[usize],
+        compute_face_normal: F,
+    ) -> Result<()>
+    where
+        F: Fn([f32; 3], [f32; 3], [f32; 3]) -> [f32; 3],
+    {
+        let mut vertex_map = HashMap::new();
+        for (index, vertex) in self.vertices.iter().enumerate() {
+            vertex_map.insert(
+                SmoothVertexKey::new(vertex.position, vertex.feature_id),
+                index,
+            );
+        }
+
+        for tri in triangulated.chunks_exact(3) {
+            let p0 = positions[tri[0]];
+            let p1 = positions[tri[1]];
+            let p2 = positions[tri[2]];
+            let normal = compute_face_normal(p0, p1, p2);
+
+            for position in [p0, p1, p2] {
+                let vertex_index =
+                    self.vertex_index_for_position(position, feature_id, &mut vertex_map)?;
+                self.vertices[vertex_index].normal[0] += normal[0];
+                self.vertices[vertex_index].normal[1] += normal[1];
+                self.vertices[vertex_index].normal[2] += normal[2];
+                self.indices.push(
+                    u32::try_from(vertex_index).context("GLB vertex count exceeds u32 range")?,
+                );
+            }
+        }
+
+        Ok(())
+    }
+
+    fn vertex_index_for_position(
+        &mut self,
+        position: [f32; 3],
+        feature_id: u32,
+        vertex_map: &mut HashMap<SmoothVertexKey, usize>,
+    ) -> Result<usize> {
+        let key = SmoothVertexKey::new(position, feature_id);
+        if let Some(index) = vertex_map.get(&key).copied() {
+            return Ok(index);
+        }
+
+        let index = self.vertices.len();
+        self.vertices.push(Vertex {
+            position,
+            normal: [0.0; 3],
+            feature_id,
+        });
+        vertex_map.insert(key, index);
+        Ok(index)
+    }
+
+    fn normalize_normals(&mut self) {
+        for vertex in &mut self.vertices {
+            let length = (vertex.normal[0] * vertex.normal[0]
+                + vertex.normal[1] * vertex.normal[1]
+                + vertex.normal[2] * vertex.normal[2])
+                .sqrt();
+            if length > f32::EPSILON {
+                vertex.normal[0] /= length;
+                vertex.normal[1] /= length;
+                vertex.normal[2] /= length;
+            } else {
+                vertex.normal = [0.0, 0.0, 1.0];
+            }
+        }
     }
 
     fn optimize(&mut self) -> Result<()> {
@@ -1002,6 +1106,7 @@ impl ProcessedScene {
             [0.0; 3]
         };
         for primitive in primitives.values_mut() {
+            primitive.normalize_normals();
             for vertex in &mut primitive.vertices {
                 vertex.position[0] -= center[0];
                 vertex.position[1] -= center[1];

--- a/cityjson-convert/src/gltf_writer.rs
+++ b/cityjson-convert/src/gltf_writer.rs
@@ -1004,7 +1004,7 @@ impl RawPrimitiveMesh {
 
             for position in [p0, p1, p2] {
                 let vertex_index =
-                    self.vertex_index_for_position(position, feature_id, &mut vertex_map)?;
+                    self.vertex_index_for_position(position, feature_id, &mut vertex_map);
                 self.vertices[vertex_index].normal[0] += normal[0];
                 self.vertices[vertex_index].normal[1] += normal[1];
                 self.vertices[vertex_index].normal[2] += normal[2];
@@ -1022,10 +1022,10 @@ impl RawPrimitiveMesh {
         position: [f32; 3],
         feature_id: u32,
         vertex_map: &mut HashMap<SmoothVertexKey, usize>,
-    ) -> Result<usize> {
+    ) -> usize {
         let key = SmoothVertexKey::new(position, feature_id);
         if let Some(index) = vertex_map.get(&key).copied() {
-            return Ok(index);
+            return index;
         }
 
         let index = self.vertices.len();
@@ -1035,7 +1035,7 @@ impl RawPrimitiveMesh {
             feature_id,
         });
         vertex_map.insert(key, index);
-        Ok(index)
+        index
     }
 
     fn normalize_normals(&mut self) {

--- a/cityjson-convert/src/lib.rs
+++ b/cityjson-convert/src/lib.rs
@@ -22,6 +22,7 @@ use cityjson_lib::CityModel;
 use log::info;
 
 #[derive(Clone, Debug)]
+#[allow(clippy::struct_excessive_bools)]
 pub struct ExportOptions {
     pub native_glb_color: String,
     pub metadata_class_name: String,

--- a/cityjson-convert/src/lib.rs
+++ b/cityjson-convert/src/lib.rs
@@ -30,6 +30,7 @@ pub struct ExportOptions {
     pub source_crs: Option<String>,
     pub ecef_origin: Option<[f64; 3]>,
     pub reproject_to_ecef: bool,
+    pub smooth_normals: bool,
     pub quantize_geometry: bool,
     pub meshopt_compression: bool,
 }
@@ -44,6 +45,7 @@ impl Default for ExportOptions {
             source_crs: None,
             ecef_origin: None,
             reproject_to_ecef: true,
+            smooth_normals: false,
             quantize_geometry: true,
             meshopt_compression: true,
         }

--- a/cityjson-convert/src/main.rs
+++ b/cityjson-convert/src/main.rs
@@ -20,6 +20,9 @@ struct Cli {
     /// Disable geometry quantization in the generated GLB.
     #[arg(long = "no-quantization", default_value_t = false)]
     no_quantization: bool,
+    /// Share vertices and average incident face normals.
+    #[arg(long = "smooth-normals", default_value_t = false)]
+    smooth_normals: bool,
     /// Disable `EXT_meshopt_compression` in the generated GLB.
     #[arg(long = "no-meshopt-compression", default_value_t = false)]
     no_meshopt_compression: bool,
@@ -41,6 +44,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         source_crs: None,
         ecef_origin: None,
         reproject_to_ecef: true,
+        smooth_normals: cli.smooth_normals,
         quantize_geometry: !cli.no_quantization,
         meshopt_compression: !cli.no_meshopt_compression,
     };

--- a/cityjson-convert/tests/gltf_writer_geometry.rs
+++ b/cityjson-convert/tests/gltf_writer_geometry.rs
@@ -342,6 +342,58 @@ fn convert_to_glb_can_disable_only_meshopt_compression() {
 }
 
 #[test]
+fn convert_to_glb_can_generate_smooth_normals() {
+    let model = json::merge_feature_stream_slice(include_bytes!("data/ams_up_holes.city.jsonl"))
+        .expect("fixture feature stream should parse");
+    let hard_output_path = stable_output_path("ams-up-hard-normals");
+    let smooth_output_path = stable_output_path("ams-up-smooth-normals");
+
+    let hard_options = ExportOptions {
+        quantize_geometry: false,
+        meshopt_compression: false,
+        ..ExportOptions::default()
+    };
+    let smooth_options = ExportOptions {
+        smooth_normals: true,
+        quantize_geometry: false,
+        meshopt_compression: false,
+        ..ExportOptions::default()
+    };
+
+    convert_to_glb(&model, &hard_output_path, &hard_options)
+        .expect("hard-normal GLB conversion should succeed");
+    convert_to_glb(&model, &smooth_output_path, &smooth_options)
+        .expect("smooth-normal GLB conversion should succeed");
+
+    let hard_glb_bytes = fs::read(&hard_output_path).expect("hard-normal test GLB should exist");
+    let smooth_glb_bytes =
+        fs::read(&smooth_output_path).expect("smooth-normal test GLB should exist");
+    let hard_root = read_glb_json(&hard_glb_bytes);
+    let smooth_root = read_glb_json(&smooth_glb_bytes);
+
+    let hard_accessors = hard_root["accessors"]
+        .as_array()
+        .expect("hard-normal glTF should contain accessors");
+    let smooth_accessors = smooth_root["accessors"]
+        .as_array()
+        .expect("smooth-normal glTF should contain accessors");
+
+    let hard_vertex_count = hard_accessors[0]["count"].as_u64().unwrap();
+    let smooth_vertex_count = smooth_accessors[0]["count"].as_u64().unwrap();
+    let hard_index_count = hard_accessors[3]["count"].as_u64().unwrap();
+    let smooth_index_count = smooth_accessors[3]["count"].as_u64().unwrap();
+
+    assert!(
+        smooth_vertex_count < hard_vertex_count,
+        "smooth normals should deduplicate shared vertices"
+    );
+    assert_eq!(
+        smooth_index_count, hard_index_count,
+        "smoothing should preserve triangle topology"
+    );
+}
+
+#[test]
 fn convert_to_glb_merges_multiple_features_into_one_centered_mesh() {
     let model =
         json::merge_feature_stream_slice(include_bytes!("data/multi_feature_types.city.jsonl"))

--- a/src/main.rs
+++ b/src/main.rs
@@ -195,6 +195,7 @@ fn build_glb_export_options(
         source_crs,
         ecef_origin,
         reproject_to_ecef: true,
+        smooth_normals: cli.smooth_normals,
         quantize_geometry: true,
         meshopt_compression: true,
     }


### PR DESCRIPTION
Implements a smooth-normals option for the GLTF writer. Wired up to the existing Tyler CLI smooth-normals flag.