### PR TITLE
Use geographic tiling for implicit tiling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 
 - Tyler now takes a single dataset root input instead of separate `--metadata` and `--features` arguments.
 - Tyler no longer depends on an external `geoflow-bundle` installation for GLB export.
+- For implicit 3DTiles, tiling is now performed in geographic coordinates
+- 3DTiles now use bounding volume region instead of box
 - README, Dockerfiles, Nix flake files, and bundled resources were updated for the new pipeline.
 
 ## tyler 0.3.14 (2025-10-22)

--- a/README.md
+++ b/README.md
@@ -261,7 +261,18 @@ For example:
 
 #### Bounding volumes
 
-*tyler* represents the tile's bounding volume as a [Box](https://docs.ogc.org/cs/22-025r4/22-025r4.html#core-box).
+*tyler* represents 3D Tiles tile bounding volumes as
+[`region`](https://docs.ogc.org/cs/22-025r4/22-025r4.html#core-region)
+values in EPSG:4979.
+
+For explicit tilesets, tiles are still generated from the source CRS grid and
+each tile writes its own transformed geographic region.
+
+For implicit tilesets, content tile IDs follow the implicit geographic
+subdivision of the root region: `x` subdivides longitude and `y` subdivides
+latitude. Implicit tilesets use additive refinement so parent and child content
+can coexist when source-leaf content appears at mixed implicit levels. The GLB
+content remains encoded in the shared root ENU frame.
 
 For explicit tilesets, it is possible to add a tightly-fitted bounding volume to the [tile's content](https://docs.ogc.org/cs/22-025r4/22-025r4.html#core-content-bounding-volume).
 You can enable this with the `--3dtiles-content-add-bv` option.

--- a/docs/adr/004-use-geographic-implicit-tiling-for-region-bounds.md
+++ b/docs/adr/004-use-geographic-implicit-tiling-for-region-bounds.md
@@ -1,0 +1,174 @@
+# Use Geographic Implicit Tiling for Region Bounds
+
+## Status
+
+Accepted
+
+## Related Commits
+
+- none yet
+
+## Context
+
+Tyler builds 3D Tiles from a source-CRS grid and quadtree. This works well for
+explicit tilesets because every explicit tile writes its own transformed
+`boundingVolume.region`. The tile ID may come from a projected source CRS grid,
+but the tile boundary in `tileset.json` is computed for that exact tile by
+transforming its source bbox to EPSG:4979.
+
+Implicit tiling is different. An implicit tileset writes one root bounding
+volume and the viewer derives child tile bounds by subdivision. For
+`boundingVolume.region`, the subdivision axes are geographic:
+
+```text
+x = longitude subdivision
+y = latitude subdivision
+height range is inherited by quadtree children
+```
+
+After moving implicit root bounds from `box` to `region`, Tyler still mapped
+implicit content URIs from the source-CRS quadtree IDs:
+
+```text
+t/{level}/{x}/{y}.glb
+```
+
+This created a mismatch:
+
+- GLB content was placed correctly on the globe using the shared root ENU frame
+- implicit tile bounds were derived by longitude/latitude subdivision
+- content tile IDs still represented source-CRS grid subdivision
+
+The result in viewers such as Cesium was that GLB content and implicit tile
+bounds did not line up.
+
+There was also a separate refinement issue during the first geographic tiling
+implementation. Content could appear on both parent and child implicit tiles.
+With `refine: "REPLACE"`, the viewer may drop parent content when child content
+is selected. If parent content is not a deliberate lower-detail replacement for
+complete child content, this can make geometry disappear while zooming in. A
+brief deepest-level-only fix avoided that, but it could create too many GLB
+tiles for large outputs. An ancestor-merging fix was also rejected because it
+could create overly large content tiles. Tyler now uses additive refinement for
+implicit tiles instead.
+
+## Decision
+
+For implicit 3D Tiles that use `boundingVolume.region`, Tyler will assign
+content to geographic implicit tile IDs.
+
+Concretely:
+
+1. Explicit tiling remains source-CRS based.
+   - The source grid and quadtree remain the internal tiling model.
+   - Each explicit tile writes its own transformed EPSG:4979 region.
+   - This preserves the source-CRS tiling path for explicit 3D Tiles and future
+     non-3D-Tiles output formats.
+
+2. Implicit 3D Tiles use geographic content tile IDs.
+   - The root implicit region is derived from the root source bbox transformed
+     to EPSG:4979.
+   - Feature bounds are transformed to geographic longitude/latitude bounds for
+     implicit tile assignment.
+   - A content URI such as `t/8/123/456.glb` means geographic implicit tile
+     `(level=8, x=123, y=456)`, where `x` subdivides longitude and `y`
+     subdivides latitude.
+
+3. GLB placement remains unchanged.
+   - Source geometry is read in the source CRS.
+   - GLB vertices are written in the shared root ENU frame.
+   - The root tile transform places that ENU frame in ECEF.
+
+4. Implicit tiles use additive refinement.
+   - Content is assigned at the corresponding source leaf level.
+   - Parent and child content may both be available in the implicit hierarchy.
+   - `refine: "ADD"` prevents parent content from disappearing when child
+     content is selected.
+
+5. Building and BuildingPart unique assignment is preserved.
+   - For `Building` and `BuildingPart`, each feature is assigned to one
+     geographic tile at the source leaf level by transformed centroid.
+   - Other feature types can still be assigned to all geographic tiles at the
+     source leaf level intersecting their transformed bbox.
+
+6. Geographic clipping is deferred.
+   - `--3dtiles-content-clip-to-tile-bounds` still applies to explicit
+     source-CRS tiles.
+   - For geographic implicit tiling, Tyler logs a warning and does not clip.
+   - Exact clipping would require clipping against geographic tile boundaries or
+     projected tile polygons, not the current source-CRS axis-aligned bbox.
+
+## Consequences
+
+Good:
+
+- implicit tile IDs now match the subdivision space of `boundingVolume.region`
+- GLB content and implicit tile bounds line up in Cesium
+- source-CRS tiling remains available for explicit output and future formats
+- `region` avoids the large-area planar-box curvature problem
+- additive refinement avoids parent content disappearing when child content is
+  selected
+- BuildingPart output does not explode into bbox-intersection duplication
+
+Trade-offs:
+
+- implicit 3D Tiles now have a separate assignment path from explicit tiles
+- feature bboxes must be transformed to EPSG:4979 for geographic implicit
+  assignment
+- transformed bbox corners are an approximation for large or curved features
+- quadtree region heights are still inherited by all implicit descendants
+- missing vertical projection grids can still produce poor region height values
+- geographic clipping remains a future task
+- additive refinement can show duplicate geometry if a feature is assigned to
+  both an ancestor and descendant content tile
+
+## Rejected Alternatives
+
+- Keep using source-CRS tile IDs for implicit `region` tiles.
+  This keeps one tile ID system but is semantically wrong for implicit region
+  subdivision. The viewer derives child bounds in longitude/latitude space, not
+  source-CRS grid space.
+
+- Switch implicit tiles back to `boundingVolume.box`.
+  A box can be made to align better with source-CRS grid axes, but large-area
+  boxes need curvature correction and are less natural for geographic viewers.
+  The move to `region` is still the right model for global bounds.
+
+- Force all implicit content to the deepest level.
+  This avoids parent/child refinement conflicts with `REPLACE`, but it can
+  create many more GLB tiles than the source-leaf hierarchy.
+
+- Merge descendant content into ancestor content tiles.
+  This also avoids parent/child refinement conflicts with `REPLACE`, but it can
+  create very large content tiles when a high-level ancestor overlaps many
+  descendants.
+
+- Reproject all feature geometry before tiling.
+  Tyler only needs geographic bounds and centroid-like placement for assignment.
+  Reprojecting and storing all vertices would duplicate work already done by the
+  GLB exporter and would make the indexing path heavier.
+
+- Project geographic tile bounds back to the source CRS for assignment.
+  Geographic tile rectangles do not generally become axis-aligned source-CRS
+  rectangles. A projected source-CRS bbox would be conservative and can
+  over-assign; exact projected polygon intersection is a larger clipping/indexing
+  problem.
+
+## Notes
+
+The current geographic implicit assignment transforms bbox corners. This is a
+reasonable first implementation for compact building features. For large linear
+or area features, Tyler may need bbox-edge densification or direct selected
+vertex transformation to avoid underestimating geographic bounds.
+
+The implementation logs the number of source features, content tiles, and
+feature-tile assignments for geographic implicit tiling. This is useful for
+spotting accidental duplication or unexpectedly large implicit output.
+
+Future work:
+
+- add geographic clipping for implicit tile content
+- improve geographic bounds for large projected bboxes
+- add warnings for suspicious EPSG:4979 height ranges
+- decide whether very large datasets need multi-subtree implicit output instead
+  of a single root subtree

--- a/docs/adr/004-use-geographic-implicit-tiling-for-region-bounds.md
+++ b/docs/adr/004-use-geographic-implicit-tiling-for-region-bounds.md
@@ -6,7 +6,8 @@ Accepted
 
 ## Related Commits
 
-- none yet
+- 7ba9bef04805753d2e8ee3bb762c891d2431cf12
+- ad853afd987089c6907e70d82055593440bf4b6c
 
 ## Context
 
@@ -82,6 +83,7 @@ Concretely:
 4. Implicit tiles use additive refinement.
    - Content is assigned at the corresponding source leaf level.
    - Parent and child content may both be available in the implicit hierarchy.
+   - The implicit root tile template is serialized with `refine: "ADD"`.
    - `refine: "ADD"` prevents parent content from disappearing when child
      content is selected.
 

--- a/src/formats.rs
+++ b/src/formats.rs
@@ -775,6 +775,7 @@ pub mod cesium3dtiles {
                 bounding_volume: None,
                 uri: "t/{level}/{x}/{y}.glb".to_string(),
             });
+            self.root.refine = Some(Refinement::Add);
             self.root.children = None;
 
             vec![Self::implicit_root_subtree_from_content_tile_ids(

--- a/src/formats.rs
+++ b/src/formats.rs
@@ -19,6 +19,7 @@ pub mod cesium3dtiles {
     //! Supported version: 1.1.
     //! Not supported: `extras`.
     use std::collections::HashMap;
+    use std::collections::HashSet;
     use std::collections::VecDeque;
     use std::fmt::{Display, Formatter};
     use std::fs::File;
@@ -398,6 +399,7 @@ pub mod cesium3dtiles {
         /// Convert to implicit tiling.
         /// It modifies the tileset and deletes the explicit tiles.
         /// Expects that explicit tiling is already created.
+        #[allow(dead_code)]
         pub fn make_implicit(
             &mut self,
             grid: &SquareGrid,
@@ -745,8 +747,181 @@ pub mod cesium3dtiles {
                 bounding_volume: None,
                 uri: "t/{level}/{x}/{y}.glb".to_string(),
             });
+            self.root.refine = Some(Refinement::Add);
             self.root.children = None;
             (flat_tiles_with_content, subtrees_vec)
+        }
+
+        /// Convert the root tile to an implicit tileset using content tile IDs
+        /// that already follow the implicit subdivision coordinate system.
+        pub fn make_implicit_from_content_tile_ids(
+            &mut self,
+            content_tile_ids: &[TileId],
+            subtrees_dir: Option<&str>,
+        ) -> Vec<(TileId, Vec<u8>)> {
+            let available_levels = self.available_levels();
+            let subtree_levels = available_levels;
+            let subtrees = match subtrees_dir {
+                None => Subtrees::default(),
+                Some(dirname) => Subtrees::new(dirname),
+            };
+            self.root.implicit_tiling = Some(ImplicitTiling {
+                subdivision_scheme: SubdivisionScheme::Quadtree,
+                subtree_levels,
+                available_levels,
+                subtrees,
+            });
+            self.root.content = Some(Content {
+                bounding_volume: None,
+                uri: "t/{level}/{x}/{y}.glb".to_string(),
+            });
+            self.root.children = None;
+
+            vec![Self::implicit_root_subtree_from_content_tile_ids(
+                available_levels,
+                content_tile_ids,
+            )]
+        }
+
+        fn implicit_root_subtree_from_content_tile_ids(
+            available_levels: u16,
+            content_tile_ids: &[TileId],
+        ) -> (TileId, Vec<u8>) {
+            let mut available_tiles = HashSet::new();
+            let mut content_tiles = HashSet::new();
+
+            for tile_id in content_tile_ids {
+                if tile_id.level >= available_levels {
+                    warn!(
+                        "Skipping implicit content tile {} because availableLevels is {}",
+                        tile_id, available_levels
+                    );
+                    continue;
+                }
+
+                content_tiles.insert(tile_id.clone());
+                for ancestor_level in 0..=tile_id.level {
+                    let shift = tile_id.level - ancestor_level;
+                    available_tiles.insert(TileId::new(
+                        tile_id.x >> shift,
+                        tile_id.y >> shift,
+                        ancestor_level,
+                    ));
+                }
+            }
+
+            let nr_tiles_total_subtree = (4_usize.pow(available_levels as u32) - 1) / 3;
+            let mut tile_availability_bitstream: bv::BitVec<u8, bv::Lsb0> = bv::BitVec::new();
+            tile_availability_bitstream.resize(nr_tiles_total_subtree, false);
+            let mut content_availability_bitstream: bv::BitVec<u8, bv::Lsb0> = bv::BitVec::new();
+            content_availability_bitstream.resize(nr_tiles_total_subtree, false);
+
+            for tile_id in available_tiles {
+                let index = Self::implicit_tile_bit_index(&tile_id);
+                if index < nr_tiles_total_subtree {
+                    tile_availability_bitstream.set(index, true);
+                }
+            }
+            for tile_id in content_tiles {
+                let index = Self::implicit_tile_bit_index(&tile_id);
+                if index < nr_tiles_total_subtree {
+                    content_availability_bitstream.set(index, true);
+                }
+            }
+
+            let nr_tiles_child_level = 4_usize.pow(available_levels as u32);
+            let mut child_subtree_availability_bitstream: bv::BitVec<u8, bv::Lsb0> =
+                bv::BitVec::new();
+            child_subtree_availability_bitstream.resize(nr_tiles_child_level, false);
+
+            let subtree_id = TileId::new(0, 0, 0);
+            (
+                subtree_id,
+                Self::subtree_bytes_from_availability(
+                    &tile_availability_bitstream,
+                    &content_availability_bitstream,
+                    &child_subtree_availability_bitstream,
+                ),
+            )
+        }
+
+        fn implicit_tile_bit_index(tile_id: &TileId) -> usize {
+            let level_offset = (4_usize.pow(tile_id.level as u32) - 1) / 3;
+            let morton_index = morton_encode([tile_id.y as u64, tile_id.x as u64]) as usize;
+            level_offset + morton_index
+        }
+
+        fn subtree_bytes_from_availability(
+            tile_availability_bitstream: &bv::BitVec<u8, bv::Lsb0>,
+            content_availability_bitstream: &bv::BitVec<u8, bv::Lsb0>,
+            child_subtree_availability_bitstream: &bv::BitVec<u8, bv::Lsb0>,
+        ) -> Vec<u8> {
+            let mut buffer_vec: Vec<u8> = Vec::new();
+            let mut bufferviews: Vec<BufferView> = Vec::with_capacity(3);
+            let mut bufferview_idx: usize = 0;
+
+            let mut tile_availability_bits = tile_availability_bitstream.clone();
+            let tile_availability =
+                Self::create_availability(bufferview_idx, &mut tile_availability_bits);
+            if tile_availability.constant.is_none() {
+                Self::add_padding(&mut buffer_vec, 8);
+                Self::add_bitstream(&mut buffer_vec, &mut bufferviews, tile_availability_bits);
+                bufferview_idx += 1;
+            }
+
+            let mut content_availability_bits = content_availability_bitstream.clone();
+            let content_availability =
+                Self::create_availability(bufferview_idx, &mut content_availability_bits);
+            if content_availability.constant.is_none() {
+                Self::add_padding(&mut buffer_vec, 8);
+                Self::add_bitstream(&mut buffer_vec, &mut bufferviews, content_availability_bits);
+                bufferview_idx += 1;
+            }
+
+            let mut child_subtree_availability_bits = child_subtree_availability_bitstream.clone();
+            let child_subtree_availability =
+                Self::create_availability(bufferview_idx, &mut child_subtree_availability_bits);
+            if child_subtree_availability.constant.is_none() {
+                Self::add_padding(&mut buffer_vec, 8);
+                Self::add_bitstream(
+                    &mut buffer_vec,
+                    &mut bufferviews,
+                    child_subtree_availability_bits,
+                );
+            }
+
+            Self::add_padding(&mut buffer_vec, 8);
+
+            let buffer = Buffer {
+                name: None,
+                byte_length: buffer_vec.len(),
+            };
+            let subtree = Subtree {
+                buffers: Some(vec![buffer]),
+                buffer_views: Some(bufferviews),
+                tile_availability,
+                content_availability: Some(vec![content_availability]),
+                child_subtree_availability,
+            };
+            let mut subtree_json =
+                serde_json::to_string(&subtree).expect("failed to serialize the subtree to json");
+            let remainder = subtree_json.as_bytes().len() % 8;
+            if remainder > 0 {
+                let padding = 8 - remainder;
+                for _i in 0..padding {
+                    subtree_json += " ";
+                }
+            }
+            let subtree_json_bytes = subtree_json.as_bytes();
+
+            let mut subtree_bytes: Vec<u8> = Vec::new();
+            subtree_bytes.extend(0x74627573u32.to_le_bytes());
+            subtree_bytes.extend(1_u32.to_le_bytes());
+            subtree_bytes.extend((subtree_json_bytes.len() as u64).to_le_bytes());
+            subtree_bytes.extend((buffer_vec.len() as u64).to_le_bytes());
+            subtree_bytes.extend(subtree_json_bytes);
+            subtree_bytes.extend(buffer_vec);
+            subtree_bytes
         }
 
         fn add_padding(buffer_vec: &mut Vec<u8>, align_by: usize) {
@@ -797,6 +972,7 @@ pub mod cesium3dtiles {
             }
         }
 
+        #[allow(dead_code)]
         fn tile_corner_coordinate(grid: &SquareGrid, qtree: &QuadTree, tile: &Tile) -> String {
             let tileid = &tile.id;
             let qtree_nodeid: QuadTreeNodeId = tileid.into();
@@ -808,6 +984,7 @@ pub mod cesium3dtiles {
         /// Build a map of grid-cell-corner-coorinates and cell ID-s.
         /// It is used for matching the "theoretical grid" to the quadtree nodes, based
         /// on the coordinates.
+        #[allow(dead_code)]
         fn grid_coordinate_map(
             level_current: u32,
             extent_width: f64,
@@ -1163,7 +1340,9 @@ pub mod cesium3dtiles {
         }
     }
 
-    #[derive(Clone, Debug, Default, Eq, PartialEq)]
+    #[derive(
+        Serialize, Deserialize, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd,
+    )]
     pub struct TileId {
         pub(crate) x: usize,
         pub(crate) y: usize,

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,7 +64,7 @@ mod parser;
 mod proj;
 mod spatial_structs;
 
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fs;
 use std::fs::File;
 use std::io::Write;
@@ -72,10 +72,12 @@ use std::path::{Path, PathBuf};
 
 use crate::coordinates::RootEnuFrame;
 use crate::formats::cesium3dtiles::{Tile, TileId};
+use crate::proj::Proj;
 use cityjson_lib::cityjson::prelude::{CityObjectHandle, GeometryHandle};
 use clap::Parser;
 use log::{debug, info, log_enabled, warn, Level};
 use rayon::prelude::*;
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, clap::ValueEnum, Eq, PartialEq)]
 #[clap(rename_all = "lower")]
@@ -105,6 +107,22 @@ struct PreparedInput {
     source: parser::InputSource,
     metadata_path: PathBuf,
     feature_base_document: Option<Vec<u8>>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct TileExportJob {
+    source_tile: Option<Tile>,
+    source_tile_id: Option<TileId>,
+    content_tile_id: TileId,
+    feature_ids: Vec<usize>,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct GeographicBounds {
+    west: f64,
+    south: f64,
+    east: f64,
+    north: f64,
 }
 
 fn build_glb_export_options(
@@ -297,6 +315,219 @@ fn collect_tile_feature_ids(
         }
     }
     feature_ids
+}
+
+fn explicit_tile_export_jobs(
+    world: &parser::World,
+    quadtree: &spatial_structs::QuadTree,
+    tileset: &formats::cesium3dtiles::Tileset,
+) -> Vec<TileExportJob> {
+    tileset
+        .collect_leaves()
+        .into_iter()
+        .filter_map(|tile_ref| {
+            let tile = tile_ref.clone();
+            let qtree_nodeid: spatial_structs::QuadTreeNodeId = (&tile.id).into();
+            let qtree_node = quadtree.node(&qtree_nodeid)?;
+            let feature_ids = collect_tile_feature_ids(world, qtree_node);
+            Some(TileExportJob {
+                source_tile: Some(tile.clone()),
+                source_tile_id: Some(tile.id.clone()),
+                content_tile_id: tile.id,
+                feature_ids,
+            })
+        })
+        .collect()
+}
+
+fn geographic_implicit_tile_export_jobs(
+    world: &parser::World,
+    quadtree: &spatial_structs::QuadTree,
+    tileset: &formats::cesium3dtiles::Tileset,
+    root_region: GeographicBounds,
+    transformer: &Proj,
+) -> Result<Vec<TileExportJob>, Box<dyn std::error::Error>> {
+    let mut content_tile_features: HashMap<TileId, HashSet<usize>> = HashMap::new();
+    let mut feature_geographic_bounds: HashMap<usize, GeographicBounds> = HashMap::new();
+    let unique_assignment = geographic_implicit_unique_assignment(world);
+    let mut feature_tile_assignments = 0usize;
+
+    for tile_ref in tileset.collect_leaves() {
+        let source_tile_id = tile_ref.id.clone();
+        let qtree_nodeid: spatial_structs::QuadTreeNodeId = (&source_tile_id).into();
+        let Some(qtree_node) = quadtree.node(&qtree_nodeid) else {
+            continue;
+        };
+        if qtree_node.nr_items == 0 {
+            continue;
+        }
+
+        for feature_id in collect_tile_feature_ids(world, qtree_node) {
+            let content_level = source_tile_id.level;
+            let content_tile_ids = if unique_assignment {
+                vec![geographic_tile_id_for_feature_centroid(
+                    root_region,
+                    &world.features[feature_id],
+                    content_level,
+                    transformer,
+                )?]
+            } else {
+                let feature_bounds =
+                    if let Some(bounds) = feature_geographic_bounds.get(&feature_id) {
+                        *bounds
+                    } else {
+                        let bounds = geographic_bounds_from_source_bbox(
+                            &world.features[feature_id].bbox,
+                            transformer,
+                        )?;
+                        feature_geographic_bounds.insert(feature_id, bounds);
+                        bounds
+                    };
+                geographic_tile_ids_for_bounds(root_region, feature_bounds, content_level)
+            };
+            for content_tile_id in content_tile_ids {
+                feature_tile_assignments += 1;
+                content_tile_features
+                    .entry(content_tile_id)
+                    .or_default()
+                    .insert(feature_id);
+            }
+        }
+    }
+
+    let mut jobs: Vec<TileExportJob> = content_tile_features
+        .into_iter()
+        .map(|(content_tile_id, feature_ids)| {
+            let mut feature_ids: Vec<usize> = feature_ids.into_iter().collect();
+            feature_ids.sort_unstable();
+            TileExportJob {
+                source_tile: None,
+                source_tile_id: None,
+                content_tile_id,
+                feature_ids,
+            }
+        })
+        .collect();
+    jobs.sort_by(|lhs, rhs| lhs.content_tile_id.cmp(&rhs.content_tile_id));
+    info!(
+        "Geographic implicit tiling assigned {} source features to {} content tiles ({} feature-tile assignments)",
+        world.features.len(),
+        jobs.len(),
+        feature_tile_assignments
+    );
+    Ok(jobs)
+}
+
+fn geographic_implicit_unique_assignment(world: &parser::World) -> bool {
+    world.cityobject_types.as_ref().is_some_and(|types| {
+        types.iter().any(|object_type| {
+            matches!(
+                object_type,
+                parser::CityObjectType::Building | parser::CityObjectType::BuildingPart
+            )
+        })
+    })
+}
+
+fn geographic_tile_id_for_feature_centroid(
+    root: GeographicBounds,
+    feature: &parser::Feature,
+    level: u16,
+    transformer: &Proj,
+) -> Result<TileId, Box<dyn std::error::Error>> {
+    let z = f64::midpoint(feature.bbox[2], feature.bbox[5]);
+    let (lon, lat, _height) =
+        transformer.convert((feature.centroid()[0], feature.centroid()[1], z))?;
+    let tiles_per_axis = 1_usize << level;
+    let tile_width = (root.east - root.west) / tiles_per_axis as f64;
+    let tile_height = (root.north - root.south) / tiles_per_axis as f64;
+
+    Ok(TileId::new(
+        geographic_tile_index(lon, root.west, tile_width, tiles_per_axis),
+        geographic_tile_index(lat, root.south, tile_height, tiles_per_axis),
+        level,
+    ))
+}
+
+fn geographic_bounds_from_source_bbox(
+    bbox: &spatial_structs::Bbox,
+    transformer: &Proj,
+) -> Result<GeographicBounds, Box<dyn std::error::Error>> {
+    let mut west = f64::INFINITY;
+    let mut south = f64::INFINITY;
+    let mut east = f64::NEG_INFINITY;
+    let mut north = f64::NEG_INFINITY;
+
+    for [x, y, z] in bbox_corners(bbox) {
+        let (lon, lat, _height) = transformer.convert((x, y, z))?;
+        west = west.min(lon);
+        south = south.min(lat);
+        east = east.max(lon);
+        north = north.max(lat);
+    }
+
+    Ok(GeographicBounds {
+        west,
+        south,
+        east,
+        north,
+    })
+}
+
+fn geographic_tile_ids_for_bounds(
+    root: GeographicBounds,
+    bounds: GeographicBounds,
+    level: u16,
+) -> Vec<TileId> {
+    let tiles_per_axis = 1_usize << level;
+    let tile_width = (root.east - root.west) / tiles_per_axis as f64;
+    let tile_height = (root.north - root.south) / tiles_per_axis as f64;
+
+    if tile_width <= 0.0 || tile_height <= 0.0 {
+        return Vec::new();
+    }
+
+    let x_min = geographic_tile_index(bounds.west, root.west, tile_width, tiles_per_axis);
+    let x_max = geographic_tile_index(bounds.east, root.west, tile_width, tiles_per_axis);
+    let y_min = geographic_tile_index(bounds.south, root.south, tile_height, tiles_per_axis);
+    let y_max = geographic_tile_index(bounds.north, root.south, tile_height, tiles_per_axis);
+
+    let mut tile_ids = Vec::new();
+    for y in y_min..=y_max {
+        for x in x_min..=x_max {
+            tile_ids.push(TileId::new(x, y, level));
+        }
+    }
+    tile_ids
+}
+
+fn geographic_tile_index(value: f64, origin: f64, tile_size: f64, tiles_per_axis: usize) -> usize {
+    let max_index = tiles_per_axis.saturating_sub(1) as isize;
+    (((value - origin) / tile_size).floor() as isize).clamp(0, max_index) as usize
+}
+
+fn bbox_corners(bbox: &spatial_structs::Bbox) -> [[f64; 3]; 8] {
+    [
+        [bbox[0], bbox[1], bbox[2]],
+        [bbox[0], bbox[1], bbox[5]],
+        [bbox[0], bbox[4], bbox[2]],
+        [bbox[0], bbox[4], bbox[5]],
+        [bbox[3], bbox[1], bbox[2]],
+        [bbox[3], bbox[1], bbox[5]],
+        [bbox[3], bbox[4], bbox[2]],
+        [bbox[3], bbox[4], bbox[5]],
+    ]
+}
+
+fn tiles_results_successful_content_tile_ids(
+    all_content_tile_ids: &[TileId],
+    failed_content_tile_ids: &HashSet<TileId>,
+) -> Vec<TileId> {
+    all_content_tile_ids
+        .iter()
+        .filter(|tile_id| !failed_content_tile_ids.contains(*tile_id))
+        .cloned()
+        .collect()
 }
 
 fn read_tile_feature_models(
@@ -752,26 +983,36 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         tileset.export(Some(&debug_data_output_path))?;
     }
 
-    let (tiles, _subtrees) = match cli.cesium3dtiles_implicit {
+    let source_crs = format!("EPSG:{}", world.crs.to_epsg()?);
+    let source_to_geographic = Proj::new_known_crs(&source_crs, "EPSG:4979", None)?;
+    let root_geographic_bounds =
+        geographic_bounds_from_source_bbox(&quadtree.bbox(&world.grid), &source_to_geographic)?;
+
+    let export_jobs = match cli.cesium3dtiles_implicit {
         true => {
+            if cli.cesium3dtiles_content_clip_to_tile_bounds {
+                warn!("--3dtiles-content-clip-to-tile-bounds is not applied for geographic implicit tiling yet");
+            }
+            let export_jobs = geographic_implicit_tile_export_jobs(
+                &world,
+                &quadtree,
+                &tileset,
+                root_geographic_bounds,
+                &source_to_geographic,
+            )?;
+            let content_tile_ids: Vec<TileId> = export_jobs
+                .iter()
+                .map(|job| job.content_tile_id.clone())
+                .collect();
             let mut tileset_implicit = tileset.clone();
-            // FIXME: here we have a Vec<(Tile, TileId)> in 'tiles' instead of Vec<&Tile>, because of the
-            //  mess with the implicit/explicit tile id-s.
-            info!("Converting to implicit tiling");
-            // Tileset.make_implicit() outputs the tiles that have content. If only the leaves have
-            //  content, then only the leaves are outputted.
+            info!("Converting to geographic implicit tiling");
             let components: Vec<_> = subtrees_path_unpruned
                 .components()
                 .map(|comp| comp.as_os_str())
                 .collect();
             let subtrees_dir_option = components.last().cloned().unwrap().to_str();
-            let tiles_subtrees = tileset_implicit.make_implicit(
-                &world.grid,
-                &quadtree,
-                cli.grid_export,
-                subtrees_dir_option,
-                Some(&debug_data_output_path),
-            );
+            let subtrees = tileset_implicit
+                .make_implicit_from_content_tile_ids(&content_tile_ids, subtrees_dir_option);
 
             if cli.cesium3dtiles_tileset_only || log_enabled!(Level::Debug) {
                 info!("Writing unpruned 3D Tiles tileset");
@@ -779,7 +1020,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
                 info!("Writing unpruned subtrees for implicit tiling");
                 fs::create_dir_all(&subtrees_path_unpruned)?;
-                for (subtree_id, subtree_bytes) in &tiles_subtrees.1 {
+                for (subtree_id, subtree_bytes) in &subtrees {
                     fs::create_dir_all(
                         subtrees_path_unpruned
                             .join(format!("{}/{}", subtree_id.level, subtree_id.x)),
@@ -796,21 +1037,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 }
             }
 
-            tiles_subtrees
+            export_jobs
         }
         false => {
-            let just_tiles = tileset.collect_leaves();
-            // FIXME: here we need Vec<(Tile, TileId)> instead of Vec<&Tile>, for the same reason
-            //  as above
-            let tiles: Vec<(Tile, TileId)> = just_tiles
-                .into_iter()
-                .map(|tile_ref| (tile_ref.clone(), tile_ref.id.clone()))
-                .collect();
+            let export_jobs = explicit_tile_export_jobs(&world, &quadtree, &tileset);
 
             info!("Writing unpruned 3D Tiles tileset");
             tileset.to_file(&tileset_path_unpruned)?;
 
-            (tiles, vec![])
+            export_jobs
         }
     };
 
@@ -827,7 +1062,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             info!("Created output directory {:#?}", &path_features_input_dir);
         }
 
-        let source_crs = format!("EPSG:{}", world.crs.to_epsg()?);
         let geometry_placement = cityjson_convert::GeometryPlacement::Enu {
             source_crs,
             ecef_origin: root_enu_frame.ecef_origin,
@@ -837,46 +1071,53 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         };
         let export_options = build_glb_export_options(&cli, geometry_placement, None);
         let feature_type_lods = build_feature_type_lods(&cli);
-        let tiles_len = tiles.len();
-        let tiles_failed_iter = tiles.into_par_iter().map(|(tile, tileid)| {
-            let tileid_grid = &tile.id;
-            let qtree_nodeid: spatial_structs::QuadTreeNodeId = tileid_grid.into();
-            let qtree_node = quadtree
-                .node(&qtree_nodeid)
-                .unwrap_or_else(|| panic!("did not find tile {} in quadtree", tileid_grid));
-            if qtree_node.nr_items == 0 {
+        let tiles_len = export_jobs.len();
+        let all_content_tile_ids: Vec<TileId> = export_jobs
+            .iter()
+            .map(|job| job.content_tile_id.clone())
+            .collect();
+        let tiles_failed_iter = export_jobs.into_par_iter().map(|job| {
+            if job.feature_ids.is_empty() {
                 // The Tileset.prune() method removes the empty tiles from the tileset,
                 //  so skipping the tile conversion without failure is ok if it's empty.
-                debug!("Tile is empty ({}), skipping conversion", tileid_grid);
+                debug!(
+                    "Tile is empty ({}), skipping conversion",
+                    job.content_tile_id
+                );
                 return None;
             }
-            let tileid_string = tileid.to_string();
+            let tileid_string = job.content_tile_id.to_string();
             let file_name = tileid_string;
             let output_file = path_output_tiles.join(&file_name).with_extension("glb");
-            let feature_ids = collect_tile_feature_ids(&world, qtree_node);
-            let model =
-                match build_tile_model_from_feature_ids(&world, &feature_ids, &feature_type_lods) {
-                    Ok(model) => model,
+            let model = match build_tile_model_from_feature_ids(
+                &world,
+                &job.feature_ids,
+                &feature_type_lods,
+            ) {
+                Ok(model) => model,
+                Err(error) => {
+                    warn!(
+                        "Failed to build CityJSON model for tile {}: {}",
+                        job.content_tile_id, error
+                    );
+                    return Some(job);
+                }
+            };
+            if cli.debug_tile_inputs {
+                let cityjsonseq_bytes = match build_tile_debug_cityjsonseq(
+                    &world,
+                    &job.feature_ids,
+                    &feature_type_lods,
+                ) {
+                    Ok(bytes) => bytes,
                     Err(error) => {
                         warn!(
-                            "Failed to build CityJSON model for tile {}: {}",
-                            tileid_grid, error
+                            "Failed to build debug CityJSONFeature stream for tile {}: {}",
+                            job.content_tile_id, error
                         );
-                        return Some(tile);
+                        return Some(job);
                     }
                 };
-            if cli.debug_tile_inputs {
-                let cityjsonseq_bytes =
-                    match build_tile_debug_cityjsonseq(&world, &feature_ids, &feature_type_lods) {
-                        Ok(bytes) => bytes,
-                        Err(error) => {
-                            warn!(
-                                "Failed to build debug CityJSONFeature stream for tile {}: {}",
-                                tileid_grid, error
-                            );
-                            return Some(tile);
-                        }
-                    };
                 if let Err(error) = write_debug_tile_input(
                     &path_features_input_dir,
                     file_name.as_str(),
@@ -884,34 +1125,40 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 ) {
                     warn!(
                         "Failed to write debug CityJSONFeature stream for tile {}: {}",
-                        tileid_grid, error
+                        job.content_tile_id, error
                     );
-                    return Some(tile);
+                    return Some(job);
                 }
             }
             let mut tile_export_options = export_options.clone();
-            if cli.cesium3dtiles_content_clip_to_tile_bounds {
-                tile_export_options.clip_bbox = Some(qtree_node.bbox(&world.grid));
+            if cli.cesium3dtiles_content_clip_to_tile_bounds && !cli.cesium3dtiles_implicit {
+                if let Some(source_tile_id) = &job.source_tile_id {
+                    let qtree_nodeid: spatial_structs::QuadTreeNodeId = source_tile_id.into();
+                    let qtree_node = quadtree.node(&qtree_nodeid).unwrap_or_else(|| {
+                        panic!("did not find tile {} in quadtree", source_tile_id)
+                    });
+                    tile_export_options.clip_bbox = Some(qtree_node.bbox(&world.grid));
+                }
             }
             if let Err(error) =
                 cityjson_convert::convert_to_glb(&model, &output_file, &tile_export_options)
             {
-                warn!("Tile {} conversion failed: {}", tileid_grid, error);
-                return Some(tile);
+                warn!("Tile {} conversion failed: {}", job.content_tile_id, error);
+                return Some(job);
             }
             if !output_file.exists() {
                 warn!(
                     "Tile {} conversion failed: {} was not created",
-                    tileid_grid,
+                    job.content_tile_id,
                     output_file.display()
                 );
-                return Some(tile);
+                return Some(job);
             }
 
             None
         });
 
-        let mut tiles_results: Vec<Option<Tile>> = Vec::with_capacity(tiles_len + 2);
+        let mut tiles_results: Vec<Option<TileExportJob>> = Vec::with_capacity(tiles_len + 2);
         if let Some(tiles_results_path) = debug_data.tiles_results {
             info!("Loading tiles_results from {tiles_results_path:?}");
             let tiles_results_file = File::open(tiles_results_path)?;
@@ -929,32 +1176,32 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 bincode::serialize_into(tiles_results_file, &tiles_results)?;
             }
         }
-        let tiles_failed: Vec<Tile> = tiles_results.into_iter().flatten().collect();
+        let tiles_failed: Vec<TileExportJob> = tiles_results.into_iter().flatten().collect();
         info!("Done");
 
         info!("Pruning tileset of {} failed tiles", tiles_failed.len());
         for (i, failed) in tiles_failed.iter().enumerate() {
-            debug!("{}, removing failed from the tileset: {}", i, failed.id);
+            debug!(
+                "{}, removing failed from the tileset: {}",
+                i, failed.content_tile_id
+            );
         }
-        // Remove tiles that failed the gltf conversion
-        tileset.prune(&tiles_failed, &quadtree);
         if cli.cesium3dtiles_implicit {
-            // FIXME: here we re-create the implicit tileset from the pruned tileset,
-            //  because it is simpler than flipping the bits of the unavailable tiles,
-            //  because of the mixed up explicit/implicit tile IDs. But ideally, we
-            //  flip the bits, so we won't need to duplicate the tileset here.
+            let failed_content_tile_ids: HashSet<TileId> = tiles_failed
+                .iter()
+                .map(|failed| failed.content_tile_id.clone())
+                .collect();
+            let content_tile_ids: Vec<TileId> = tiles_results_successful_content_tile_ids(
+                &all_content_tile_ids,
+                &failed_content_tile_ids,
+            );
             let components: Vec<_> = subtrees_path
                 .components()
                 .map(|comp| comp.as_os_str())
                 .collect();
             let subtrees_dir_option = components.last().cloned().unwrap().to_str();
-            let (_, subtrees) = tileset.make_implicit(
-                &world.grid,
-                &quadtree,
-                cli.grid_export,
-                subtrees_dir_option,
-                Some(&debug_data_output_path),
-            );
+            let subtrees =
+                tileset.make_implicit_from_content_tile_ids(&content_tile_ids, subtrees_dir_option);
             info!("Writing subtrees for implicit tiling");
             fs::create_dir_all(&subtrees_path)?;
             for (subtree_id, subtree_bytes) in subtrees {
@@ -972,6 +1219,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 }
             }
         } else {
+            let failed_tiles: Vec<Tile> = tiles_failed
+                .into_iter()
+                .filter_map(|failed| failed.source_tile)
+                .collect();
+            // Remove tiles that failed the gltf conversion
+            tileset.prune(&failed_tiles, &quadtree);
             let available_levels = tileset.available_levels();
             // A five level deep tree is still managable in size.
             if available_levels > 5 {
@@ -1376,5 +1629,33 @@ mod tests {
 
         assert!(!model.cityobjects().is_empty());
         assert!(!model.vertices().is_empty());
+    }
+
+    #[test]
+    fn geographic_bounds_map_to_lon_lat_implicit_tile_ids() {
+        let root = GeographicBounds {
+            west: 0.0,
+            south: 50.0,
+            east: 4.0,
+            north: 54.0,
+        };
+        let bounds = GeographicBounds {
+            west: 2.1,
+            south: 51.1,
+            east: 3.9,
+            north: 52.9,
+        };
+
+        let tile_ids = geographic_tile_ids_for_bounds(root, bounds, 2);
+
+        assert_eq!(
+            tile_ids,
+            vec![
+                TileId::new(2, 1, 2),
+                TileId::new(3, 1, 2),
+                TileId::new(2, 2, 2),
+                TileId::new(3, 2, 2),
+            ]
+        );
     }
 }

--- a/tests/3dtiles_coordinate_frame.rs
+++ b/tests/3dtiles_coordinate_frame.rs
@@ -146,6 +146,11 @@ fn debug_replay_writes_epsg4979_regions_and_local_enu_glbs() {
 
     assert_tile_bounding_volumes_are_regions(root);
     assert_eq!(
+        root["refine"].as_str(),
+        Some("ADD"),
+        "implicit root should use additive refinement so parent content remains visible"
+    );
+    assert_eq!(
         root["content"]["uri"].as_str(),
         Some("t/{level}/{x}/{y}.glb")
     );


### PR DESCRIPTION
This implements tiling in geographic coordinates for 3dtiles with implicit tiling. That should fix issues due to misalignment of origin source CRS tile bounds and the implicit bounds from region bounding volume.

I left the option to do tiling in source CRS intact, and it is currently still used for explicit tiling. We probably want to use it for other output formats when we add them as well.

I tested it on the AMS subset that I have, and it looks good. But should be tested nationwide as well (waiting for the upcoming perf improvements for this).

most important TODO:
- add geographic clipping for implicit tile content. Clipping still happens in source CRS now, which will probably cause some misalignment.

More details in ADR 004