### PR TITLE
Optimize CityJSON processing for tile reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 - `cityjson-index` backed runs now persist row-ordered feature references from
   grid indexing and reuse them during tile conversion, avoiding repeated
   feature-id lookups.
+- Grid indexing for `cityjson-index` inputs now consumes decoded scan pages
+  directly instead of paging references and issuing per-feature reads.
 - Tile conversion now uses thread-local `CityIndex` handles for cjindex reads
   and defers normal per-feature cleanup until after tile model merging.
 - Tyler now takes a single dataset root input instead of separate `--metadata` and `--features` arguments.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@
 
 ### Changed
 
+- `cityjson-index` backed runs now persist row-ordered feature references from
+  grid indexing and reuse them during tile conversion, avoiding repeated
+  feature-id lookups.
+- Tile conversion now uses thread-local `CityIndex` handles for cjindex reads
+  and defers normal per-feature cleanup until after tile model merging.
 - Tyler now takes a single dataset root input instead of separate `--metadata` and `--features` arguments.
 - Tyler no longer depends on an external `geoflow-bundle` installation for GLB export.
 - README, Dockerfiles, Nix flake files, and bundled resources were updated for the new pipeline.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -295,7 +295,6 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 [[package]]
 name = "cityjson"
 version = "0.8.0"
-source = "git+https://github.com/3DGI/cityjson?branch=main#3eb784b4e3517645203ccd4c5cb92470ab349e77"
 dependencies = [
  "num 0.4.3",
 ]
@@ -322,7 +321,6 @@ dependencies = [
 [[package]]
 name = "cityjson-index"
 version = "0.8.0"
-source = "git+https://github.com/3DGI/cityjson?branch=main#3eb784b4e3517645203ccd4c5cb92470ab349e77"
 dependencies = [
  "cityjson-lib",
  "clap",
@@ -343,7 +341,6 @@ dependencies = [
 [[package]]
 name = "cityjson-json"
 version = "0.8.0"
-source = "git+https://github.com/3DGI/cityjson?branch=main#3eb784b4e3517645203ccd4c5cb92470ab349e77"
 dependencies = [
  "ahash",
  "cityjson",
@@ -355,7 +352,6 @@ dependencies = [
 [[package]]
 name = "cityjson-lib"
 version = "0.8.0"
-source = "git+https://github.com/3DGI/cityjson?branch=main#3eb784b4e3517645203ccd4c5cb92470ab349e77"
 dependencies = [
  "cityjson",
  "cityjson-json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -295,6 +295,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 [[package]]
 name = "cityjson"
 version = "0.8.0"
+source = "git+https://github.com/3DGI/cityjson?branch=main#f8c23408c8a37222a19d2430e5bfc66a51458c71"
 dependencies = [
  "num 0.4.3",
 ]
@@ -321,6 +322,7 @@ dependencies = [
 [[package]]
 name = "cityjson-index"
 version = "0.8.0"
+source = "git+https://github.com/3DGI/cityjson?branch=main#f8c23408c8a37222a19d2430e5bfc66a51458c71"
 dependencies = [
  "cityjson-lib",
  "clap",
@@ -341,6 +343,7 @@ dependencies = [
 [[package]]
 name = "cityjson-json"
 version = "0.8.0"
+source = "git+https://github.com/3DGI/cityjson?branch=main#f8c23408c8a37222a19d2430e5bfc66a51458c71"
 dependencies = [
  "ahash",
  "cityjson",
@@ -352,6 +355,7 @@ dependencies = [
 [[package]]
 name = "cityjson-lib"
 version = "0.8.0"
+source = "git+https://github.com/3DGI/cityjson?branch=main#f8c23408c8a37222a19d2430e5bfc66a51458c71"
 dependencies = [
  "cityjson",
  "cityjson-json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -255,9 +255,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -294,9 +294,8 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "cityjson"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b0c00b7277c1fb62a17298376f0c5ea8196d516b75d3e009a3daaaa2b2243dc"
+version = "0.8.0"
+source = "git+https://github.com/3DGI/cityjson?branch=main#3eb784b4e3517645203ccd4c5cb92470ab349e77"
 dependencies = [
  "num 0.4.3",
 ]
@@ -322,9 +321,8 @@ dependencies = [
 
 [[package]]
 name = "cityjson-index"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc10d4949fe45887025cb038c9cbea212ad717d9911baa894c274918f87d024"
+version = "0.8.0"
+source = "git+https://github.com/3DGI/cityjson?branch=main#3eb784b4e3517645203ccd4c5cb92470ab349e77"
 dependencies = [
  "cityjson-lib",
  "clap",
@@ -344,9 +342,8 @@ dependencies = [
 
 [[package]]
 name = "cityjson-json"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a73e71602f999b37740ae5b67604cc8bf1aae6c76778f35d5c174c4da1ef3ac7"
+version = "0.8.0"
+source = "git+https://github.com/3DGI/cityjson?branch=main#3eb784b4e3517645203ccd4c5cb92470ab349e77"
 dependencies = [
  "ahash",
  "cityjson",
@@ -357,9 +354,8 @@ dependencies = [
 
 [[package]]
 name = "cityjson-lib"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8dc3527db715ac970cf867b44a5918472afaea872a76fc6253ac6ebfbb38e58"
+version = "0.8.0"
+source = "git+https://github.com/3DGI/cityjson?branch=main#3eb784b4e3517645203ccd4c5cb92470ab349e77"
 dependencies = [
  "cityjson",
  "cityjson-json",
@@ -1307,9 +1303,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.23"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
+checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
 dependencies = [
  "jiff-static",
  "log",
@@ -1320,9 +1316,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.23"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
+checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1415,9 +1411,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libloading"
@@ -2118,9 +2114,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.38"
+version = "0.23.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
+checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
@@ -2144,9 +2140,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "web-time",
  "zeroize",
@@ -2181,9 +2177,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,8 @@ name = "tyler"
 path = "src/main.rs"
 
 [dependencies]
-cityjson-lib = "0.6.1"
-cityjson-index = "0.4.2"
+cityjson-lib = { git = "https://github.com/3DGI/cityjson", branch = "main", features = ["json"] }
+cityjson-index = { git = "https://github.com/3DGI/cityjson", branch = "main" }
 cityjson-convert = { path = "cityjson-convert" }
 log = "0.4.17"
 env_logger = "0.10.0"

--- a/cityjson-convert/Cargo.toml
+++ b/cityjson-convert/Cargo.toml
@@ -12,7 +12,7 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = "1.0"
-cityjson-lib = "0.6.1"
+cityjson-lib = { git = "https://github.com/3DGI/cityjson", branch = "main", features = ["json"] }
 clap = { version = "4.6", features = ["cargo", "derive"] }
 earcutr = "0.5.0"
 env_logger = "0.11.0"

--- a/docs/adr/005-optimize-cjindex-backed-large-input-processing.md
+++ b/docs/adr/005-optimize-cjindex-backed-large-input-processing.md
@@ -1,0 +1,200 @@
+# Optimize cjindex-Backed Large Input Processing
+
+## Status
+
+Proposed
+
+## Related Commits
+
+- `3eb784b` Optimize cityjson-index full scans
+- `2b6c380` Optimize CityJSON index processing
+
+## Context
+
+Tyler now supports `cjindex` datasets as an input abstraction. This lets Tyler
+work with `feature-files`, `ndjson`, and monolithic `cityjson` storage layouts
+through one interface, but the first implementation kept several expensive
+per-feature access patterns.
+
+On a 10,771,547 feature sidecar, an older full run showed these phases:
+
+- rebuilding the `cjindex` sidecar: about 7 minutes
+- computing the unfiltered dataset extent: about 5 hours
+- counting vertices into grid cells: about 5.5 hours
+- converting and optimizing 23,356 GLB tiles: about 66 minutes
+
+The unfiltered extent phase was caused by iterating every feature bbox page.
+The underlying `cityjson-index` page query also used a nullable predicate:
+
+```sql
+WHERE (?1 IS NULL OR f.id > ?1)
+```
+
+For large sidecars, SQLite planned this as an RTree scan plus a temporary
+sort, rather than a direct ordered range scan on `features.id`.
+
+That issue has been fixed in `cityjson-index` by:
+
+- splitting first-page and later-page SQL paths
+- using `WHERE f.id > ?` only for later pages
+- adding an aggregate bounds/count API for unfiltered extent computation
+
+Tyler now uses the aggregate bounds API for unfiltered `cjindex` extent
+computation. That should remove the old hours-scale extent scan. The next
+large costs are the remaining phases that still need to read, decode, prepare,
+and merge many features.
+
+The current grid-counting path pages feature references and then reads each
+feature individually. During tile conversion, Tyler stores only the public
+`cjindex` feature id, reopens or resolves through `CityIndex`, and then reads
+each selected tile feature by string id. This discards row-locality information
+that Tyler already sees while scanning the index.
+
+Model preparation also appears to do duplicated work. Each tile feature is
+filtered, pruned, cleaned, and has extents recomputed before merge. The merged
+tile model is then cleaned and has extents recomputed again.
+
+## Decision
+
+Tyler will optimize large `cjindex` inputs around rowid-backed feature
+references and batched reads while preserving current grid assignment
+semantics.
+
+Completed `cityjson-index` changes are part of this decision:
+
+1. `cityjson-index` uses separate first-page and later-page SQL queries for
+   full scans.
+2. Later pages use a direct rowid range predicate:
+
+   ```sql
+   WHERE f.id > ?
+   ORDER BY f.id
+   LIMIT ?
+   ```
+
+3. `cityjson-index` exposes an aggregate bounds/count helper that returns
+   `None` for empty indexes.
+4. Tyler uses that aggregate helper for unfiltered `cjindex` extent
+   computation, then applies `--grid-minz` and `--grid-maxz` clamping as
+   before.
+
+The planned follow-up work is:
+
+1. Add a public row-reference type or extend the existing feature reference in
+   `cityjson-index` so callers can keep both:
+   - the public feature id
+   - the SQLite feature rowid needed for direct reads
+2. Add row-ref or batch-read APIs to `cityjson-index`, such as:
+   - read one feature by row ref
+   - read many features by row ref
+   - scan pages that yield feature refs with decoded models
+3. Store a Tyler-owned serializable copy of the `cjindex` row ref in
+   `FeatureReference` instead of storing only `CjIndexId(String)`.
+4. Use the new row-ref or scan API in grid counting so Tyler can consume
+   rowid-ordered decoded features without resolving each feature through its
+   public string id.
+5. Use thread-local `CityIndex` handles in tile conversion, matching the grid
+   indexing strategy.
+6. Use row-ref or batch reads during tile conversion. Tile refs may be sorted
+   by rowid before reading when that does not change output semantics.
+7. Audit tile model preparation and, if behavior is preserved, defer
+   `cleanup_and_update_extents` until after feature models are merged.
+
+No Tyler CLI changes are required for this work.
+
+## Required Semantics
+
+The optimization must preserve Tyler's observable tiling behavior.
+
+In particular:
+
+- selected-vertex counting remains part of the grid ownership score
+- bbox-intersected cells remain candidates as they are today
+- unique ownership for feature classes that require it remains unchanged
+- tile contents remain selected by the same quadtree/grid feature membership
+- feature type filtering, LoD pruning, and optional parent attribute
+  inheritance keep their current behavior
+- aggregate extent computation must produce the same unfiltered extent as the
+  previous iterative bbox scan, except for existing min/max z clamping options
+
+## Consequences
+
+Good:
+
+- unfiltered extent computation no longer requires reading every bbox page
+- full scans can use ordered rowid range queries instead of nullable predicates
+- Tyler can avoid resolving public feature ids repeatedly during later phases
+- grid counting can be driven by row-local scan or batch APIs
+- tile conversion can reduce repeated SQLite setup and point lookups
+- rowid-sorted batch reads should improve locality for large sidecars
+- deferring cleanup and extent recomputation may remove duplicated per-feature
+  work during tile export
+
+Trade-offs:
+
+- Tyler's serialized world/debug state needs a richer `cjindex` feature
+  reference
+- `cityjson-index` must expose row-reference APIs carefully, without making
+  storage details unstable for callers
+- batch APIs add more public surface that needs tests for ordering, missing
+  rows, and page boundaries
+- deferring cleanup requires focused regression tests because filtering and
+  parent/root handling are subtle
+
+## Rejected Alternatives
+
+- Keep using only public string feature ids.
+  This is simple, but it forces repeated id resolution and prevents direct
+  rowid-based reads in the hot paths.
+
+- Only increase `CJINDEX_PAGE_SIZE`.
+  Larger pages reduce some overhead, but they do not address per-feature string
+  lookups or repeated point reads during tile conversion.
+
+- Cache every decoded feature model in Tyler.
+  This would avoid repeated decoding, but 10M+ features make a full decoded
+  cache too memory-heavy for the expected datasets.
+
+- Change grid ownership semantics while optimizing.
+  That would make performance results hard to compare and could alter tile
+  assignment. Ownership changes belong in a separate decision.
+
+- Remove per-feature cleanup without tests.
+  The duplicated cleanup is a good optimization candidate, but it must be
+  proven against filtering, LoD pruning, inherited attributes, empty geometry
+  removal, and final tile extents.
+
+## Validation Plan
+
+For `cityjson-index`:
+
+- verify later page scans use `SEARCH f USING INTEGER PRIMARY KEY (rowid>?)`
+  in `EXPLAIN QUERY PLAN`
+- test first page, later pages, page boundaries, and no skipped or duplicated
+  refs
+- test aggregate bounds/count against iterative bounds on small fixtures
+- test row-ref and batch-read APIs against `get(feature_id)`
+
+For Tyler:
+
+- test row-ref serialization and round-trip through world/debug data
+- test optimized grid counting against the current behavior, including cells
+  overlapped only by bbox
+- test tile conversion reads the same features through row refs as through
+  public ids
+- test deferred cleanup, if implemented, against filtering, LoD pruning,
+  parent attributes, empty geometry removal, and final extents
+
+For performance:
+
+- benchmark after the aggregate extent fix to establish the new baseline
+- measure grid counting separately from feature read/decode time
+- measure tile conversion subphases:
+  - collect tile feature ids
+  - read/decode features
+  - prepare feature models
+  - merge
+  - cleanup and extent update
+  - GLB encode/write
+- compare wall time on the large sidecar using the same input path, feature
+  count, tile count, output path location, and release build settings

--- a/src/main.rs
+++ b/src/main.rs
@@ -546,10 +546,18 @@ fn filter_cityjsonfeature_preserving_root<F>(
     predicate: F,
 ) -> Result<cityjson_lib::CityModel, Box<dyn std::error::Error>>
 where
-    F: FnMut(cityjson_lib::ops::FilterContext<'_>) -> bool,
+    F: FnMut(cityjson_lib::ops::CityObjectSelectionContext<'_>) -> bool,
 {
     let had_feature_root = model.id().is_some();
-    let mut filtered = cityjson_lib::ops::filter(model, predicate)?;
+    let selection = cityjson_lib::ops::select_cityobjects(model, predicate)?;
+    let mut filtered = if selection.is_empty() {
+        let mut empty = model.clone();
+        empty.clear_cityobjects();
+        empty.set_id(None);
+        empty
+    } else {
+        cityjson_lib::ops::extract(model, &selection)?
+    };
 
     if !had_feature_root || filtered.id().is_some() || filtered.cityobjects().is_empty() {
         return Ok(filtered);

--- a/src/main.rs
+++ b/src/main.rs
@@ -320,20 +320,41 @@ fn read_tile_feature_models(
             }
         }
         parser::InputSource::CjIndexDataset { .. } => {
-            let city_index = world.input_source.open_index()?;
+            let mut cjindex_refs = Vec::with_capacity(feature_ids.len());
             for fid in feature_ids {
-                let parser::FeatureReference::CjIndexId(feature_id) =
-                    &world.features[*fid].reference
-                else {
-                    return Err(
-                        "cjindex input unexpectedly referenced a legacy feature path".into(),
-                    );
-                };
-                let model = city_index.get(feature_id)?.ok_or_else(|| {
-                    format!("feature {feature_id} could not be resolved from cjindex")
-                })?;
-                models.push(model);
+                match &world.features[*fid].reference {
+                    parser::FeatureReference::CjIndexRef(feature) => {
+                        cjindex_refs.push(feature.clone());
+                    }
+                    parser::FeatureReference::CjIndexId(_) => {
+                        let city_index = world.input_source.open_index()?;
+                        for fid in feature_ids {
+                            let parser::FeatureReference::CjIndexId(feature_id) =
+                                &world.features[*fid].reference
+                            else {
+                                return Err(
+                                    "cjindex input mixed row references with legacy feature ids"
+                                        .into(),
+                                );
+                            };
+                            let model = city_index.get(feature_id)?.ok_or_else(|| {
+                                format!("feature {feature_id} could not be resolved from cjindex")
+                            })?;
+                            models.push(model);
+                        }
+                        return Ok(models);
+                    }
+                    parser::FeatureReference::LegacyPath(_) => {
+                        return Err(
+                            "cjindex input unexpectedly referenced a legacy feature path".into(),
+                        );
+                    }
+                }
             }
+            models = parser::World::read_cjindex_features_thread_local(
+                &world.input_source,
+                &cjindex_refs,
+            )?;
         }
     }
 
@@ -351,6 +372,7 @@ fn build_tile_model_from_feature_ids(
         feature_ids,
         feature_type_lods,
         include_parent_attributes,
+        false,
     )?;
     if models.is_empty() {
         return Err("tile model preparation removed all CityObjects".into());
@@ -379,6 +401,7 @@ fn build_tile_debug_cityjsonseq(
         feature_ids,
         feature_type_lods,
         include_parent_attributes,
+        true,
     )?;
     let base_root = cityjson_lib::json::from_slice(&world.feature_base_document)?;
     let mut feature_output = Vec::new();
@@ -396,12 +419,18 @@ fn prepare_tile_feature_models(
     feature_ids: &[usize],
     feature_type_lods: &BTreeMap<String, String>,
     include_parent_attributes: bool,
+    cleanup_features: bool,
 ) -> Result<Vec<cityjson_lib::CityModel>, Box<dyn std::error::Error>> {
     read_tile_feature_models(world, feature_ids)?
         .into_iter()
         .filter_map(|model| {
-            match prepare_feature_model(model, world, feature_type_lods, include_parent_attributes)
-            {
+            match prepare_feature_model(
+                model,
+                world,
+                feature_type_lods,
+                include_parent_attributes,
+                cleanup_features,
+            ) {
                 Ok(Some(model)) => Some(Ok(model)),
                 Ok(None) => None,
                 Err(error) => Some(Err(error)),
@@ -415,6 +444,7 @@ fn prepare_feature_model(
     world: &parser::World,
     feature_type_lods: &BTreeMap<String, String>,
     include_parent_attributes: bool,
+    cleanup_feature: bool,
 ) -> Result<Option<cityjson_lib::CityModel>, Box<dyn std::error::Error>> {
     let mut model = filter_cityobject_types(model, world.cityobject_types.as_ref())?;
     prune_lod_geometries(&mut model, feature_type_lods)?;
@@ -425,7 +455,11 @@ fn prepare_feature_model(
     if model.cityobjects().is_empty() {
         return Ok(None);
     }
-    cleanup_and_update_extents(model).map(Some)
+    if cleanup_feature {
+        cleanup_and_update_extents(model).map(Some)
+    } else {
+        Ok(Some(model))
+    }
 }
 
 fn inherit_parent_attributes(
@@ -1620,6 +1654,10 @@ mod tests {
             assert_eq!(world.grid.bbox[5], indexed_bounds.max_z);
         }
         world.index_with_grid().expect("index cjindex ndjson world");
+        assert!(world
+            .features
+            .iter()
+            .all(|feature| matches!(feature.reference, parser::FeatureReference::CjIndexRef(_))));
         let quadtree = build_quadtree(&world);
         let model = build_tile_model(&world, &quadtree).expect("build tile model");
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -406,10 +406,23 @@ impl World {
         ]
     }
 
-    fn read_cjindex_feature_thread_local(
+    pub(crate) fn read_cjindex_feature_thread_local(
         input_source: &InputSource,
         feature: &cityjson_index::IndexedFeatureRef,
     ) -> cityjson_lib::Result<cityjson_lib::CityModel> {
+        Self::read_cjindex_features_thread_local(input_source, std::slice::from_ref(feature)).map(
+            |mut models| {
+                models
+                    .pop()
+                    .expect("single-feature batch should return one model")
+            },
+        )
+    }
+
+    pub(crate) fn read_cjindex_features_thread_local(
+        input_source: &InputSource,
+        features: &[cityjson_index::IndexedFeatureRef],
+    ) -> cityjson_lib::Result<Vec<cityjson_lib::CityModel>> {
         let InputSource::CjIndexDataset { index_path, .. } = input_source else {
             return Err(cityjson_lib::Error::Io(std::io::Error::other(
                 "cjindex feature reads require a cjindex dataset",
@@ -438,7 +451,7 @@ impl World {
                     "cjindex thread-local index cache was not initialized",
                 )));
             };
-            city_index.read_feature(feature)
+            city_index.read_features(features)
         })
     }
 
@@ -620,10 +633,8 @@ impl World {
                             let model =
                                 Self::read_cjindex_feature_thread_local(&input_source, &feature)
                                     .map_err(|error| error.to_string())?;
-                            Ok(self.index_feature_model(
-                                FeatureReference::CjIndexId(feature.feature_id.clone()),
-                                &model,
-                            ))
+                            Ok(self
+                                .index_feature_model(FeatureReference::CjIndexRef(feature), &model))
                         })
                         .collect::<Result<Vec<_>, String>>()?;
                     for feature_in_cells in feature_in_cells.into_iter().flatten() {
@@ -814,6 +825,7 @@ impl Feature {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum FeatureReference {
     LegacyPath(PathBuf),
+    CjIndexRef(cityjson_index::IndexedFeatureRef),
     CjIndexId(String),
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -14,7 +14,6 @@
 // limitations under the License.
 
 use std::cell::RefCell;
-use std::collections::HashMap;
 use std::fmt;
 use std::fs::File;
 use std::path::{Path, PathBuf};
@@ -30,7 +29,7 @@ use walkdir::WalkDir;
 
 use crate::spatial_structs::{Bbox, Cell, CellId};
 
-const CJINDEX_PAGE_SIZE: usize = 4096;
+const CJINDEX_PAGE_SIZE: usize = 65_536;
 
 thread_local! {
     static CJINDEX_THREAD_LOCAL: RefCell<Option<(PathBuf, CityIndex)>> = const { RefCell::new(None) };
@@ -345,23 +344,15 @@ impl World {
     fn extent_from_cjindex_bbox_pages(
         city_index: &CityIndex,
     ) -> Result<(Option<Bbox>, usize, usize, Vec<CityObjectType>), Box<dyn std::error::Error>> {
-        let mut extent: Option<Bbox> = None;
-        let mut nr_features = 0usize;
-
-        for page_result in city_index.iter_all_bbox_pages(CJINDEX_PAGE_SIZE)? {
-            let page = page_result?;
-            for feature in page {
-                if let Some(current) = extent.as_mut() {
-                    let feature_bbox = Self::cjindex_bounds_to_world_bbox(&feature.bounds);
-                    merge_bbox(current, &feature_bbox);
-                } else {
-                    extent = Some(Self::cjindex_bounds_to_world_bbox(&feature.bounds));
-                }
-                nr_features += 1;
-            }
-        }
-
-        Ok((extent, nr_features, 0, Vec::new()))
+        let Some(summary) = city_index.feature_bounds_summary()? else {
+            return Ok((None, 0, 0, Vec::new()));
+        };
+        Ok((
+            Some(Self::cjindex_bounds_to_world_bbox(&summary.bounds)),
+            summary.feature_count,
+            0,
+            Vec::new(),
+        ))
     }
 
     fn extent_from_cjindex_features(
@@ -705,7 +696,7 @@ impl World {
 
     fn feature_to_cells(
         feature: Feature,
-        cell_vtx_cnt: HashMap<CellId, usize>,
+        cell_vtx_cnt: CellCounts,
         selected_object_types: &[CityObjectType],
     ) -> Option<FeatureInGridCells> {
         let unique_assignment = selected_object_types.iter().any(|cotype| {
@@ -717,7 +708,10 @@ impl World {
         let mut cells: Vec<(CellId, Cell)> = Vec::with_capacity(cell_vtx_cnt.len());
 
         if unique_assignment {
-            let (cellid, nr_vertices) = cell_vtx_cnt.iter().max_by(|a, b| a.1.cmp(b.1)).unwrap();
+            let (cellid, nr_vertices) = cell_vtx_cnt
+                .iter()
+                .max_by(|a, b| a.1.cmp(b.1))
+                .expect("non-empty cell counts should have a maximum");
             cells.push((
                 *cellid,
                 Cell {
@@ -964,25 +958,94 @@ fn count_vertices_in_grid(
     selected_vertices: &[GeometryVertexIndex<u32>],
     grid: &crate::spatial_structs::SquareGrid,
     bbox: &Bbox,
-) -> HashMap<CellId, usize> {
-    let mut cell_vtx_cnt: HashMap<CellId, usize> = HashMap::new();
+) -> CellCounts {
+    if selected_vertices.is_empty() {
+        return CellCounts::default();
+    }
 
+    let mut vertex_cells = Vec::with_capacity(selected_vertices.len());
     for vertex_ref in selected_vertices {
         let Some(vertex) = model.vertices().get(*vertex_ref) else {
             continue;
         };
         let point = [vertex.x(), vertex.y()];
-        let cellid = grid.locate_point(&point);
-        *cell_vtx_cnt.entry(cellid).or_insert(1) += 1;
+        vertex_cells.push(grid.locate_point(&point));
     }
 
-    if !selected_vertices.is_empty() {
-        for cellid in grid.intersect_bbox(bbox) {
-            *cell_vtx_cnt.entry(cellid).or_insert(1) += 1;
+    if vertex_cells.is_empty() {
+        return CellCounts::default();
+    }
+
+    vertex_cells.sort_unstable();
+
+    let mut vertex_counts: Vec<(CellId, usize)> = Vec::with_capacity(vertex_cells.len());
+    for cellid in vertex_cells {
+        if let Some((last_cellid, count)) = vertex_counts.last_mut() {
+            if *last_cellid == cellid {
+                *count += 1;
+                continue;
+            }
         }
+        vertex_counts.push((cellid, 2));
     }
 
-    cell_vtx_cnt
+    CellCounts::merge_vertex_counts_with_bbox(vertex_counts, grid, bbox)
+}
+
+#[derive(Default)]
+struct CellCounts {
+    entries: Vec<(CellId, usize)>,
+}
+
+impl CellCounts {
+    fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    fn iter(&self) -> impl Iterator<Item = (&CellId, &usize)> {
+        self.entries.iter().map(|(cellid, count)| (cellid, count))
+    }
+
+    fn merge_vertex_counts_with_bbox(
+        vertex_counts: Vec<(CellId, usize)>,
+        grid: &crate::spatial_structs::SquareGrid,
+        bbox: &Bbox,
+    ) -> Self {
+        let (columns, rows) = grid.intersect_bbox_ranges(bbox);
+        let min_column = *columns.start();
+        let max_column = *columns.end();
+        let min_row = *rows.start();
+        let max_row = *rows.end();
+        let bbox_len = (max_column - min_column + 1) * (max_row - min_row + 1);
+        let mut entries = Vec::with_capacity(vertex_counts.len().max(bbox_len));
+        let mut vertex_counts = vertex_counts.into_iter().peekable();
+
+        for row in min_row..=max_row {
+            for column in min_column..=max_column {
+                let bbox_cellid = CellId { row, column };
+                while let Some((cellid, count)) =
+                    vertex_counts.next_if(|(cellid, _)| *cellid < bbox_cellid)
+                {
+                    entries.push((cellid, count));
+                }
+
+                if let Some((_, count)) =
+                    vertex_counts.next_if(|(cellid, _)| *cellid == bbox_cellid)
+                {
+                    entries.push((bbox_cellid, count + 1));
+                } else {
+                    entries.push((bbox_cellid, 2));
+                }
+            }
+        }
+
+        entries.extend(vertex_counts);
+        Self { entries }
+    }
 }
 
 fn is_selected_type(filter: Option<&Vec<CityObjectType>>, object_type: CityObjectType) -> bool {
@@ -1199,9 +1262,101 @@ mod tests {
         let building_cell = grid.locate_point(&[0.0, 0.0]);
         let road_cell = grid.locate_point(&[100.0, 100.0]);
 
-        assert!(counts.contains_key(&building_cell));
-        assert!(!counts.contains_key(&road_cell));
+        assert!(counts.iter().any(|(cellid, _)| *cellid == building_cell));
+        assert!(!counts.iter().any(|(cellid, _)| *cellid == road_cell));
 
         let _ = std::fs::remove_file(feature_path);
+    }
+
+    #[test]
+    fn count_vertices_in_grid_matches_reference_hashmap_counts() {
+        let base = serde_json::to_vec(&serde_json::json!({
+            "type": "CityJSON",
+            "version": "2.0",
+            "CityObjects": {},
+            "vertices": [],
+            "transform": {
+                "scale": [1.0, 1.0, 1.0],
+                "translate": [0.0, 0.0, 0.0]
+            }
+        }))
+        .unwrap();
+        let feature = serde_json::json!({
+            "type": "CityJSONFeature",
+            "id": "building-1",
+            "CityObjects": {
+                "building-1": {
+                    "type": "Building",
+                    "geometry": [{
+                        "type": "MultiSurface",
+                        "lod": "1.0",
+                        "boundaries": [[[0, 1, 2, 3]]]
+                    }]
+                }
+            },
+            "vertices": [
+                [0, 0, 0],
+                [1, 0, 0],
+                [0, 1, 0],
+                [250, 250, 0]
+            ]
+        });
+        let feature_path = std::env::temp_dir().join(format!(
+            "tyler-parser-grid-counts-{}.city.jsonl",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::write(&feature_path, serde_json::to_vec(&feature).unwrap()).unwrap();
+
+        let model = from_feature_file_with_base(&feature_path, &base).unwrap();
+        let stats = selected_geometry_stats(&model, Some(&vec![CityObjectType::Building]));
+        let bbox = stats.bbox.unwrap();
+        let grid = crate::spatial_structs::SquareGrid::new(
+            &[0.0, 0.0, 0.0, 300.0, 300.0, 10.0],
+            100,
+            7415,
+        );
+
+        let optimized = count_vertices_in_grid(&model, &stats.selected_vertices, &grid, &bbox);
+        let reference =
+            reference_count_vertices_in_grid(&model, &stats.selected_vertices, &grid, &bbox);
+
+        assert_eq!(
+            optimized
+                .iter()
+                .map(|(cellid, count)| (*cellid, *count))
+                .collect::<Vec<_>>(),
+            reference
+        );
+
+        let _ = std::fs::remove_file(feature_path);
+    }
+
+    fn reference_count_vertices_in_grid(
+        model: &cityjson::v2_0::OwnedCityModel,
+        selected_vertices: &[GeometryVertexIndex<u32>],
+        grid: &crate::spatial_structs::SquareGrid,
+        bbox: &Bbox,
+    ) -> Vec<(CellId, usize)> {
+        let mut cell_vtx_cnt = std::collections::BTreeMap::new();
+
+        for vertex_ref in selected_vertices {
+            let Some(vertex) = model.vertices().get(*vertex_ref) else {
+                continue;
+            };
+            let point = [vertex.x(), vertex.y()];
+            let cellid = grid.locate_point(&point);
+            *cell_vtx_cnt.entry(cellid).or_insert(1) += 1;
+        }
+
+        if !selected_vertices.is_empty() {
+            for cellid in grid.intersect_bbox(bbox) {
+                *cell_vtx_cnt.entry(cellid).or_insert(1) += 1;
+            }
+        }
+
+        cell_vtx_cnt.into_iter().collect()
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -406,19 +406,6 @@ impl World {
         ]
     }
 
-    pub(crate) fn read_cjindex_feature_thread_local(
-        input_source: &InputSource,
-        feature: &cityjson_index::IndexedFeatureRef,
-    ) -> cityjson_lib::Result<cityjson_lib::CityModel> {
-        Self::read_cjindex_features_thread_local(input_source, std::slice::from_ref(feature)).map(
-            |mut models| {
-                models
-                    .pop()
-                    .expect("single-feature batch should return one model")
-            },
-        )
-    }
-
     pub(crate) fn read_cjindex_features_thread_local(
         input_source: &InputSource,
         features: &[cityjson_index::IndexedFeatureRef],
@@ -623,20 +610,18 @@ impl World {
                 }
             }
             InputSource::CjIndexDataset { .. } => {
-                let input_source = self.input_source.clone();
                 let city_index = self.input_source.open_index()?;
-                for page_result in city_index.iter_all_feature_ref_pages(CJINDEX_PAGE_SIZE)? {
+                for page_result in city_index.scan_feature_pages(CJINDEX_PAGE_SIZE)? {
                     let page = page_result?;
                     let feature_in_cells = page
                         .into_par_iter()
-                        .map(|feature| -> Result<Option<FeatureInGridCells>, String> {
-                            let model =
-                                Self::read_cjindex_feature_thread_local(&input_source, &feature)
-                                    .map_err(|error| error.to_string())?;
-                            Ok(self
-                                .index_feature_model(FeatureReference::CjIndexRef(feature), &model))
+                        .map(|feature| -> Option<FeatureInGridCells> {
+                            self.index_feature_model(
+                                FeatureReference::CjIndexRef(feature.reference),
+                                &feature.model,
+                            )
                         })
-                        .collect::<Result<Vec<_>, String>>()?;
+                        .collect::<Vec<_>>();
                     for feature_in_cells in feature_in_cells.into_iter().flatten() {
                         self.integrate_feature_in_cells(feature_in_cells);
                     }

--- a/src/spatial_structs.rs
+++ b/src/spatial_structs.rs
@@ -599,15 +599,29 @@ impl SquareGrid {
     /// Return the Cells that intersect the Bounding Box.
     pub fn intersect_bbox(&self, bbox: &Bbox) -> Vec<CellId> {
         let mut cellids: Vec<CellId> = Vec::new();
-        let [minx, miny, _, maxx, maxy, _] = *bbox;
-        let min_cellid = self.locate_point(&[minx, miny]);
-        let max_cellid = self.locate_point(&[maxx, maxy]);
-        for column in min_cellid.column..=max_cellid.column {
-            for row in min_cellid.row..=max_cellid.row {
+        let (columns, rows) = self.intersect_bbox_ranges(bbox);
+        for column in columns {
+            for row in rows.clone() {
                 cellids.push(CellId { row, column });
             }
         }
         cellids
+    }
+
+    pub fn intersect_bbox_ranges(
+        &self,
+        bbox: &Bbox,
+    ) -> (
+        std::ops::RangeInclusive<usize>,
+        std::ops::RangeInclusive<usize>,
+    ) {
+        let [minx, miny, _, maxx, maxy, _] = *bbox;
+        let min_cellid = self.locate_point(&[minx, miny]);
+        let max_cellid = self.locate_point(&[maxx, maxy]);
+        (
+            min_cellid.column..=max_cellid.column,
+            min_cellid.row..=max_cellid.row,
+        )
     }
 
     /// Exports the grid and the feature centroids into TSV files into the working directory.
@@ -910,6 +924,21 @@ mod tests {
         let res = grid.intersect_bbox(&bbox);
         assert_eq!(expected.len(), res.len());
         assert!(res.iter().all(|res_cellid| expected.contains(res_cellid)))
+    }
+
+    #[test]
+    fn test_intersect_bbox_ranges_matches_intersect_bbox() {
+        let grid = SquareGrid::new(&[0.0, 0.0, 0.0, 4.0, 4.0, 0.0], 1, 7415);
+        let bbox: Bbox = [1.2, 1.2, 0.0, 2.8, 2.8, 0.0];
+        let (columns, rows) = grid.intersect_bbox_ranges(&bbox);
+        let mut from_ranges = Vec::new();
+        for column in columns {
+            for row in rows.clone() {
+                from_ranges.push(CellId { row, column });
+            }
+        }
+
+        assert_eq!(grid.intersect_bbox(&bbox), from_ranges);
     }
 
     #[test]


### PR DESCRIPTION
This pull request introduces the following changes:

- Refactors CityJSON processing to reuse `cjindex` feature references, improving efficiency during tile reads.
- Adds ADR 005 to document the optimization methodology and provide context on design decisions.
- Implements optimization techniques for `cjindex` processing to reduce overhead and enhance performance during CityJSON index operations.

No breaking changes are introduced, and the optimizations aim to streamline CityJSON handling in the current workflow.