### PR TITLE
Add profiling setup using geodepot

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+GEODEPOT_BIN=/home/balazs/Development/geodepot/.pixi/envs/default/bin/geodepot

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 
 # misc
 /tmp
+.env
 
 # Test data
 /tests/output*
@@ -20,4 +21,3 @@
 *.tsv
 *.bincode
 *.log
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 - Support for regular CityJSON documents, CityJSONSeq documents, and the legacy CityJSONFeature-files as input, via the `cityjson-index` crate.
 - A `just ci-check` recipe and a GitHub Actions workflow that runs it.
 - ADRs and supporting documentation for the new `cityjson-index`/CityJSONSeq input model and grid traversal changes.
+- A repo-local profiling workflow driven by `just profile`, `scripts/profile-tyler.sh`, and Geodepot-backed profile-by-name resolution.
+- Per-run profiling artifacts under `docs/performance/runs/`, including structured summaries for `perf stat` and Valgrind Massif.
+- Runner selection for profiling sessions so `perf` and Massif can be run independently or together, with failed runs preserved for later inspection.
 
 ### Changed
 
@@ -26,6 +29,8 @@
   parallelism.
 - Tile conversion now uses thread-local `CityIndex` handles for cjindex reads
   and defers normal per-feature cleanup until after tile model merging.
+- The CityJSON-to-GLB pre-write path now skips redundant cleanup and filtering work where the GLB output would not change, and records extra timing information around the remaining hot spots.
+- The glTF writer and CLI logging were adjusted to make profiling runs easier to inspect.
 - 3D Tiles internal `geometricError` is now computed from tile width using
   `--geometric-error-factor`; full-detail leaf tiles use `0.0`.
 - Tyler now takes a single dataset root input instead of separate `--metadata` and `--features` arguments.

--- a/README.md
+++ b/README.md
@@ -350,16 +350,24 @@ at the case root, for example `bvz-dh-coast-5/profile-tyler.json` for the
 `bvz-dh-coast-5/bvz_dh` case spec, with the matching command-line flags.
 When `--profile` is used, `--input` and `--label` are rejected because the case
 spec already determines both.
+Use `--runner perf`, `--runner massif`, or the default `--runner all` to choose
+which profiler(s) run. This is useful when Massif is too slow for a routine
+iteration.
 
-The profiler then captures `perf stat` and Valgrind Massif summaries into a
-new directory under `docs/performance/runs/`.
+The profiler then captures the selected `perf stat` and/or Valgrind Massif
+summaries into a new directory under `docs/performance/runs/`.
 Tyler's own output is stored only in a temporary staging area during the run
 and is removed before the final profiling directory is published.
+If the script exits with an error, the staging directory is retained as a
+`<run-id>.failed/` directory under `docs/performance/runs/` so you can inspect
+partial results without rerunning long profiles.
 
 Example invocations:
 
 ```bash
 just profile -- --profile bvz-dh-coast-5/bvz_dh
+just profile -- --profile bvz-dh-coast-5/bvz_dh --runner perf
+just profile -- --profile bvz-dh-coast-5/bvz_dh --runner massif
 just profile -- --profile bvz-dh-coast-5/bvz_dh --output-root docs/performance/runs
 just profile -- --input /data/cases/demo --label manual-smoke
 ```

--- a/README.md
+++ b/README.md
@@ -336,6 +336,43 @@ It is possible to only generate the tileset, without running the glTF conversion
 This can be helpful for debugging the tileset itself.
 You can enable this with the `--3dtiles-tileset-only` option.
 
+## Contributing
+
+### Profiling
+
+Use `just profile -- --help` to see the repo-local profiling wrapper options.
+Run a profile with `just profile -- --profile <case-spec>`.
+The wrapper builds `tyler` in release mode with debuginfo and frame pointers,
+then resolves the input and the case-specific `tyler` arguments from Geodepot.
+It reads the Geodepot executable path from the repo-local `.env` file via
+`GEODEPOT_BIN`, and expects each case to carry a `profile-tyler.json` data item
+at the case root, for example `bvz-dh-coast-5/profile-tyler.json` for the
+`bvz-dh-coast-5/bvz_dh` case spec, with the matching command-line flags.
+When `--profile` is used, `--input` and `--label` are rejected because the case
+spec already determines both.
+
+The profiler then captures `perf stat` and Valgrind Massif summaries into a
+new directory under `docs/performance/runs/`.
+Tyler's own output is stored only in a temporary staging area during the run
+and is removed before the final profiling directory is published.
+
+Example invocations:
+
+```bash
+just profile -- --profile bvz-dh-coast-5/bvz_dh
+just profile -- --profile bvz-dh-coast-5/bvz_dh --output-root docs/performance/runs
+just profile -- --input /data/cases/demo --label manual-smoke
+```
+
+Profiling Dependencies:
+
+- [cargo](https://doc.rust-lang.org/cargo/)
+- [geodepot](https://github.com/3DGI/geodepot)
+- [jq](https://jqlang.github.io/jq/)
+- [git](https://git-scm.com/)
+- [massif](https://valgrind.org/docs/manual/ms-manual.html)
+- [perf](https://perfwiki.github.io/main/)
+
 ## Roadmap
 
 - [x] Parallel extent computation

--- a/README.md
+++ b/README.md
@@ -374,10 +374,8 @@ just profile -- --input /data/cases/demo --label manual-smoke
 
 Profiling Dependencies:
 
-- [cargo](https://doc.rust-lang.org/cargo/)
-- [geodepot](https://github.com/3DGI/geodepot)
+- [geodepot](https://github.com/3DBAG/geodepot)
 - [jq](https://jqlang.github.io/jq/)
-- [git](https://git-scm.com/)
 - [massif](https://valgrind.org/docs/manual/ms-manual.html)
 - [perf](https://perfwiki.github.io/main/)
 

--- a/cityjson-convert/src/gltf_writer.rs
+++ b/cityjson-convert/src/gltf_writer.rs
@@ -13,7 +13,7 @@ use cityjson_lib::cityjson::v2_0::{AttributeValue, CityObject, GeometryType, Ver
 use cityjson_lib::CityModel;
 use earcutr::earcut;
 use gltf::json;
-use log::info;
+use log::debug;
 use meshopt::{
     encode_index_buffer, encode_vertex_buffer, generate_vertex_remap,
     optimize_overdraw_in_place_decoder, optimize_vertex_cache, optimize_vertex_fetch,
@@ -98,7 +98,7 @@ pub fn write_city_model_glb<P: AsRef<Path>>(
         MeshCollector::new(coordinate_transform, options.smooth_normals, clip_volume);
     collector.add_model(model)?;
     let processed = collector.finish()?;
-    info!(
+    debug!(
         "Processed {} vertices and {} indices for the output GLB",
         processed.vertex_count(),
         processed.index_count()
@@ -1579,7 +1579,7 @@ impl ProcessedScene {
             .iter()
             .all(|primitive| primitive.vertices.is_empty())
         {
-            info!(
+            debug!(
                 "No geometry to write, creating empty GLB file at {}",
                 output_path.as_ref().display()
             );
@@ -1595,7 +1595,7 @@ impl ProcessedScene {
             return Ok(());
         }
 
-        info!(
+        debug!(
             "Writing GLB file with {} vertices and {} indices to {}",
             self.vertex_count(),
             self.index_count(),
@@ -1608,10 +1608,10 @@ impl ProcessedScene {
             .ok_or_else(|| anyhow::anyhow!("geometry bounds missing for non-empty mesh"))?;
         encoded.write(output_path.as_ref())?;
 
-        info!("GLB Summary: {}", output_path.as_ref().display());
-        info!("  Vertices: {}", self.vertex_count());
-        info!("  Indices: {}", self.index_count());
-        info!(
+        debug!("GLB Summary: {}", output_path.as_ref().display());
+        debug!("  Vertices: {}", self.vertex_count());
+        debug!("  Indices: {}", self.index_count());
+        debug!(
             "  Local coordinate range: X [{:.2}, {:.2}], Y [{:.2}, {:.2}], Z [{:.2}, {:.2}]",
             bounds.min[0],
             bounds.max[0],
@@ -1620,7 +1620,7 @@ impl ProcessedScene {
             bounds.min[2],
             bounds.max[2]
         );
-        info!(
+        debug!(
             "  Node translation: [{:.2}, {:.2}, {:.2}]",
             self.node_translation_base[0] + self.center[0],
             self.node_translation_base[1] + self.center[1],

--- a/cityjson-convert/src/lib.rs
+++ b/cityjson-convert/src/lib.rs
@@ -19,7 +19,7 @@ use std::path::Path;
 
 use anyhow::Result;
 use cityjson_lib::CityModel;
-use log::info;
+use log::debug;
 
 #[derive(Clone, Debug, Default)]
 pub enum GeometryPlacement {
@@ -92,6 +92,6 @@ pub fn convert_to_glb<P: AsRef<Path>>(
     if let Some(parent) = output.parent() {
         fs::create_dir_all(parent)?;
     }
-    info!("Writing GLB output to {}", output.display());
+    debug!("Writing GLB output to {}", output.display());
     gltf_writer::write_city_model_glb(model, output, options)
 }

--- a/cityjson-convert/src/main.rs
+++ b/cityjson-convert/src/main.rs
@@ -1,10 +1,10 @@
 use std::collections::BTreeMap;
 use std::path::PathBuf;
 
+use cityjson_convert::{convert_to_glb, ExportOptions, GeometryPlacement};
 use cityjson_lib::json;
 use clap::Parser;
-
-use cityjson_convert::{convert_to_glb, ExportOptions, GeometryPlacement};
+use log::info;
 
 #[derive(Parser, Debug)]
 #[command(author, version, about)]
@@ -48,6 +48,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         meshopt_compression: !cli.no_meshopt_compression,
     };
 
-    convert_to_glb(&model, cli.output, &options)?;
+    info!("Converting to GLB");
+    convert_to_glb(&model, &cli.output, &options)?;
+    info!("GLB written to {}", cli.output.display());
     Ok(())
 }

--- a/docs/adr/008-optimize-cityjson-to-gltf-prewrite-path.md
+++ b/docs/adr/008-optimize-cityjson-to-gltf-prewrite-path.md
@@ -1,0 +1,138 @@
+# Optimize CityJSON-to-GLB Pre-Write Path
+
+## Status
+
+Proposed
+
+## Related Commits
+
+- none yet
+
+## Context
+
+Tyler spends most of its large-input time before `gltf_writer::write_city_model_glb`.
+The hot path currently includes several layers of temporary reconstruction:
+
+- `cityjson-index` decodes features from indexed storage
+- `cityjson-json` / `cityjson-lib` materialize feature models
+- Tyler indexes features into the dense grid and builds tile membership
+- Tyler re-reads the selected tile features, prepares them, merges them, and then
+  hands a `CityModel` to `cityjson_convert::convert_to_glb`
+
+Earlier profiling and the current code audit showed repeated allocation churn in
+that path:
+
+- selected-geometry scans build and sort temporary vertex lists
+- grid counting used a full bbox-expanded `CellCounts` path even when the feature
+  class only needed a single owning cell
+- tile preparation repeated type filtering, empty-geometry cleanup, and extents
+  recomputation even when those steps could not change the GLB-relevant output
+- `cityjson-index` feature reads were being reopened and re-resolved more often
+  than necessary during tile export
+
+The current work has already reduced several of those costs inside Tyler, but the
+overall path is still split across index decode, tile preparation, and GLB write.
+The next optimizations should build on the same model rather than reintroduce
+intermediate JSON materialization.
+
+## Decision
+
+Tyler will treat the CityJSON-to-GLB pre-write path as a single optimization
+surface with two phases.
+
+### Implemented first-pass changes
+
+Tyler now:
+
+1. Tracks feature type membership during grid indexing so later tile preparation
+   can skip no-op type filtering.
+2. Uses a direct unique-assignment fast path for `Building` and `BuildingPart`
+   rather than materializing a full bbox-expanded `CellCounts` just to pick the
+   winning cell.
+3. Pre-sizes selected-geometry scratch buffers conservatively to reduce repeated
+   allocation in `selected_geometry_stats`.
+4. Skips tile-preparation work when it cannot change GLB-relevant output:
+   - type filtering is skipped when the tile is already known to contain only the
+     selected types
+   - empty-geometry cleanup is skipped when no prior step can introduce empty
+     CityObjects
+   - merged GLB models are no longer sent through `cleanup_and_update_extents`
+     before `convert_to_glb`
+5. Adds timing and count logging around the main grid-indexing and tile-export
+   substeps so the remaining hot spots can be measured directly.
+
+### Planned follow-up changes
+
+Tyler will keep the same pre-write boundary and continue optimizing the path
+before `convert_to_glb` by reducing feature reconstruction churn:
+
+1. Favor row-ref or batch-read APIs in `cityjson-index` when scanning features
+   for grid indexing and tile export.
+2. Preserve a cached parsed base model/root so feature assembly does not need to
+   serialize intermediate `serde_json::Value` data back into bytes.
+3. Prefer direct import of assembled features into `OwnedCityModel` when that can
+   be done without changing observable output.
+4. Keep tile preparation focused on the GLB-relevant geometry path, and only add
+   extra cleanup when debug CityJSON output or another explicit output mode needs
+   it.
+
+The `gltf_writer` boundary remains unchanged in this phase: it continues to
+receive `&CityModel`.
+
+## Consequences
+
+Good:
+
+- the current pass removes several redundant temporary containers in Tyler
+- future work has a clear boundary: reduce pre-write reconstruction, not GLB
+  encoding semantics
+- timing logs make it easier to compare the remaining cost of feature decode,
+  tile preparation, merge, and GLB conversion
+- the tile preparation path is now easier to reason about because no-op work is
+  skipped explicitly
+
+Trade-offs:
+
+- the optimization surface spans multiple crates, so the next pass will need
+  coordinated API changes in `cityjson-index` and possibly `cityjson-json`
+- some skipped work is now conditional on assumptions about what affects GLB
+  output, so those assumptions need regression tests
+- direct feature import and cached root reuse may require new public API surface
+  that must stay stable enough for callers outside Tyler
+
+## Rejected Alternatives
+
+- Leave the current Tyler-local improvements as a one-off patch.
+  That would fix some churn, but it would not address the repeated decode and
+  materialization work that still sits in `cityjson-index` and `cityjson-json`.
+
+- Move the optimization boundary into `gltf_writer`.
+  The writer is already downstream of the expensive reconstruction. Optimizing
+  there would not reduce the repeated feature assembly and tile-prep work that
+  happens before it.
+
+- Rewrite the pre-write path around a new ad hoc representation.
+  The repo already has a CityJSON model boundary and a 3D Tiles writer boundary.
+  Replacing both would be a larger design change than this pass needs.
+
+- Skip all cleanup unconditionally.
+  That risks changing output behavior for filtered or debug paths where cleanup
+  still matters.
+
+## Validation Plan
+
+- keep the current parity tests for unique assignment and tile-preparation skips
+- add regression tests for any future `cityjson-index` row-ref or batch-read API
+- verify that cached-base and direct-import work preserves:
+  - CityJSON
+  - CityJSONSeq / NDJSON
+  - feature-file cjindex layouts
+- compare wall time before and after each follow-up phase using the existing
+  collapsed-profile workflow
+- keep `cargo test` and workspace tests green after each step
+
+## Notes
+
+This ADR is intentionally broader than the first patch set. It records the
+current Tyler-side optimizations and the direction for the next pass so that the
+implementation can continue without reopening the same scope discussion.

--- a/docs/performance/2026-04-27-grid-cell-counting-perf-analysis.md
+++ b/docs/performance/2026-04-27-grid-cell-counting-perf-analysis.md
@@ -1,0 +1,525 @@
+# Grid Cell Counting Stage Perf Analysis
+
+Date: 2026-04-27
+
+Input profiles:
+
+- `bvz_dh_2026-04-27-215648.collapsed`
+- `ams_up_large_2026-04-27-221437.collapsed`
+- `ams_up_large_2026-04-27-223426.collapsed`
+- `ams_up_large_2026-04-27-224618.collapsed`
+
+## Focus
+
+This note analyzes the stage that starts when Tyler logs:
+
+```text
+Counting vertices in grid cells
+```
+
+The current test run spends about one minute in this stage. On the real input
+of roughly 11 million features, this stage reportedly takes about one hour out
+of a three-hour total runtime.
+
+## Code Path
+
+The log is emitted by `World::index_with_grid` in `src/parser.rs`.
+
+The stage currently does the following:
+
+1. Scans cjindex feature pages with `CJINDEX_PAGE_SIZE = 65_536`.
+2. Processes each page in parallel with Rayon.
+3. For each feature, calls `index_feature_model`.
+4. Computes selected geometry stats:
+   - selected vertex indices
+   - bbox
+   - centroid
+   - selected object types
+5. Counts selected vertices by grid cell with `count_vertices_in_grid`.
+6. Merges vertex-cell counts with every cell intersecting the feature bbox.
+7. Converts the result into feature-to-cell assignments.
+8. Integrates those assignments into the dense square grid.
+
+Important source locations:
+
+- `src/parser.rs:286`: `World::index_with_grid`
+- `src/parser.rs:315`: `selected_geometry_stats`
+- `src/parser.rs:319`: `count_vertices_in_grid`
+- `src/parser.rs:623`: large-feature parallel path threshold
+- `src/parser.rs:633`: merge vertex counts with bbox cells
+- `src/parser.rs:709`: `CellCounts::merge_vertex_counts_with_bbox`
+- `src/parser.rs:747`: selected type filtering
+
+## Profile Caveat
+
+The collapsed profile is whole-process, not sliced to the log stage.
+
+It contains 384,998 samples total, but only 44 samples are directly attributed
+to `tyler::parser::World::index_with_grid`, and zero samples are named under
+`count_vertices_in_grid` or `count_vertex_cells`.
+
+That means this file is not sufficient to precisely prove where time is spent
+inside the logged stage. The likely causes are:
+
+- the profile is dominated by other stages,
+- relevant functions were inlined into generic/library frames,
+- debug symbols or frame pointers are not enough to preserve the exact Rust
+  call path in the collapsed stacks.
+
+The next run should add explicit timing around the substeps in this stage.
+
+## Whole-Run Hotspots: Initial Mixed Profile
+
+Broad aggregates from the profile:
+
+```text
+total samples                         384,998
+proj-related                          104,148   27.05%
+allocator-ish                          61,390   15.95%
+BTreeMap::insert                       15,755    4.09%
+all alloc::collections::btree frames    20,552    5.34%
+lock/futex                             11,098    2.88%
+cityjson_index::collect_vertex_indices  2,933    0.76%
+selected_geometry_stats                   198    0.05%
+```
+
+Top leaf symbols include:
+
+```text
+libproj.so.25.9.4.0`[unknown]                         10.19%
+alloc::collections::btree::map::BTreeMap::insert        4.03%
+libc.so.6`_int_malloc                                   3.96%
+libm.so.6`__ieee754_pow_fma                             3.46%
+serde_json::value::de::::deserialize                    3.36%
+libm.so.6`__sin_fma                                     3.35%
+libm.so.6`__atan_fma                                    3.21%
+serde_json::de::Deserializer::parse_integer             2.90%
+libc.so.6`_int_free                                     2.72%
+```
+
+These numbers should not be read as stage-specific, but they do show that
+allocator churn and `BTreeMap` mutation are meaningful costs in the full run.
+
+## Buildings-Only Large-Area Profile
+
+Second input profile:
+
+```text
+ams_up_large_2026-04-27-221437.collapsed
+```
+
+This run was filtered to `Building` and `BuildingPart`.
+
+The file contains 49,113 folded stacks and 272,850 samples. The profile is
+still a whole-process collapsed profile, so it is not a clean slice of the
+`Counting vertices in grid cells` stage. However, compared with the initial
+profile, `selected_geometry_stats` is now visible enough to inspect.
+
+Broad aggregates:
+
+```text
+total samples                          272,850
+selected_geometry_stats                  2,217    0.81%
+World::index_with_grid                     115    0.04%
+count_vertices_in_grid                       0    0.00%
+count_vertex_cells                           0    0.00%
+merge_vertex_counts_with_bbox                0    0.00%
+feature_to_cells                             0    0.00%
+BTreeMap::insert                         2,015    0.74%
+all alloc::collections::btree frames      7,194    2.64%
+allocator-ish                            51,815   18.99%
+free/cfree                               87,807   32.18%
+lock/futex/spin                          82,746   30.33%
+proj-related                             26,161    9.59%
+serde_json                               27,035    9.91%
+cityjson_index                            1,140    0.42%
+```
+
+Top leaf symbols:
+
+```text
+[kernel.kallsyms]`native_queued_spin_lock_slowpath     23.79%
+libc.so.6`_int_malloc                                   6.28%
+libc.so.6`_int_free                                     4.15%
+libproj.so.25.9.4.0`[unknown]                           3.61%
+core::ptr::drop_in_place                                1.93%
+libc.so.6`malloc                                        1.66%
+libc.so.6`malloc_consolidate                            1.58%
+core::hash::BuildHasher::hash_one                       1.53%
+sqlite3VdbeExec                                         1.51%
+::write                                                 1.48%
+```
+
+For stacks containing `selected_geometry_stats`, the immediate child frames are:
+
+```text
+libc.so.6`cfree@GLIBC_2.2.5        1,909   86.11%
+<self>                               304   13.71%
+small_sort_network                     2    0.09%
+asm_sysvec_apic_timer_interrupt        1    0.05%
+quicksort                              1    0.05%
+```
+
+Interpretation:
+
+- The buildings-only run supports the earlier suspicion that allocation churn
+  is important in this path.
+- The visible `selected_geometry_stats` samples are dominated by freeing memory,
+  not by obvious arithmetic in vertex-to-grid lookup.
+- `count_vertices_in_grid`, `count_vertex_cells`,
+  `merge_vertex_counts_with_bbox`, and `feature_to_cells` still do not appear as
+  named frames, likely because they are inlined or lost in the folded stacks.
+- This profile does not prove that bbox-cell materialization alone consumes the
+  hour, but it makes an allocation-reduction optimization a better first target
+  than micro-optimizing `SquareGrid::locate_point`.
+
+Comparison with the initial mixed profile:
+
+```text
+metric                    mixed profile       buildings-only profile
+total samples             384,998             272,850
+selected_geometry_stats   198 / 0.05%         2,217 / 0.81%
+BTreeMap::insert          15,755 / 4.09%      2,015 / 0.74%
+btree frames total        20,552 / 5.34%      7,194 / 2.64%
+allocator-ish             57,634 / 14.97%     51,815 / 18.99%
+free/cfree                36,998 / 9.61%      87,807 / 32.18%
+lock/futex/spin           11,683 / 3.03%      82,746 / 30.33%
+proj-related              102,893 / 26.73%    26,161 / 9.59%
+serde_json                67,759 / 17.60%     27,035 / 9.91%
+cityjson_index            13,539 / 3.52%      1,140 / 0.42%
+```
+
+The buildings-only profile shifts away from projection and JSON parsing and
+toward allocator/free/lock costs. That is consistent with a workload dominated
+by many small feature-level temporary allocations.
+
+## Buildings-Only Profile With Better Symbols
+
+Third input profile:
+
+```text
+ams_up_large_2026-04-27-223426.collapsed
+```
+
+This profile has much better Rust stack detail. It contains 93,218 folded stacks
+and 271,416 samples.
+
+It still appears to include work outside the target grid-counting stage:
+
+```text
+cityjson_index / cityjson read path        46,825   17.25%
+cityjson_convert / glTF / GLB write path   37,888   13.96%
+```
+
+So the percentages below are still whole-profile percentages, not exact
+stage-only timings.
+
+Broad aggregates:
+
+```text
+total samples                    271,416
+selected_geometry_stats           21,782    8.03%
+World::index_with_grid             7,809    2.88%
+count_vertices_in_grid                 0    0.00%
+count_vertex_cells                     0    0.00%
+merge_vertex_counts_with_bbox          0    0.00%
+feature_to_cells                       0    0.00%
+SquareGrid::locate_point               0    0.00%
+BTreeMap::insert                   2,688    0.99%
+all btree frames                   7,623    2.81%
+RawVec / Vec growth               38,567   14.21%
+allocator-ish                     56,964   20.99%
+free/cfree                        87,883   32.38%
+lock/futex/spin                   78,628   28.97%
+proj-related                      37,228   13.72%
+serde_json                        46,042   16.96%
+cityjson-related                  93,151   34.32%
+```
+
+The important new detail is inside `selected_geometry_stats`:
+
+```text
+selected_geometry_stats total      21,782    8.03% of total
+RawVec reserve/growth inside it    19,159    7.06% of total, 87.96% of selected
+malloc inside it                    5,914    2.18% of total, 27.15% of selected
+free inside it                      1,853    0.68% of total,  8.51% of selected
+sort inside it                        529    0.19% of total,  2.43% of selected
+```
+
+Immediate children below `selected_geometry_stats`:
+
+```text
+RawVecInner::reserve::do_reserve_and_handle   19,159   87.96%
+cfree@GLIBC_2.2.5                              1,773    8.14%
+quicksort                                        363    1.67%
+<self>                                           240    1.10%
+small_sort_network                               108    0.50%
+```
+
+Interpretation:
+
+- `selected_geometry_stats` is now a clear hotspot.
+- Almost all visible time inside it is `Vec` growth/reallocation, not sorting
+  or bbox/centroid arithmetic.
+- The path at `src/parser.rs:535-536` creates empty `selected_vertices` and
+  `geometry_scratch` vectors for every feature, then
+  `collect_selected_vertex_indices` grows them while extracting geometry vertex
+  indices.
+- For buildings-only runs, optimizing this allocation pattern is now the
+  highest-confidence first step.
+- The grid-counting functions are still not visible as named frames. That may be
+  inlining, or it may mean they are cheaper than the allocation-heavy geometry
+  stats path in this profile.
+
+## Buildings-Only Profile With Half Rayon Threads
+
+Fourth input profile:
+
+```text
+ams_up_large_2026-04-27-224618.collapsed
+```
+
+This run used half the previous Rayon thread count. It contains 42,813 folded
+stacks and 176,327 samples.
+
+The main result is that allocator lock contention drops sharply. In the previous
+better-symbols run, stacks containing futex/spin-lock frames were 28.97% of
+samples. With half the Rayon threads, that drops to 3.06%.
+
+Comparison:
+
+```text
+metric                    full Rayon profile       half Rayon profile
+total samples             271,416                  176,327
+alloc/free/realloc        144,479 / 53.23%          63,757 / 36.16%
+allocator locks/futex      78,628 / 28.97%           5,399 /  3.06%
+rayon                      91,255 / 33.62%          15,598 /  8.85%
+drop/destructors           81,179 / 29.91%          22,374 / 12.69%
+cityjson read/parse        60,134 / 22.16%          56,487 / 32.04%
+glb/gltf output            45,826 / 16.88%          42,028 / 23.84%
+projection/proj            37,228 / 13.72%          31,394 / 17.80%
+grid indexing/parser       29,591 / 10.90%          13,657 /  7.75%
+selected_geometry_stats    21,782 /  8.03%           6,100 /  3.46%
+sqlite                     23,121 /  8.52%          17,113 /  9.71%
+hashing                    12,272 /  4.52%          11,565 /  6.56%
+btree map                   7,623 /  2.81%           7,221 /  4.10%
+```
+
+Top leaf symbols in the half-thread profile:
+
+```text
+libc.so.6`_int_malloc                            7.97%
+libc.so.6`_int_free                              5.51%
+libproj.so.25.9.4.0`[unknown]                    5.20%
+core::ptr::drop_in_place                         2.60%
+libc.so.6`malloc                                 2.32%
+serde_json::de::Deserializer::parse_integer      2.24%
+core::hash::BuildHasher::hash_one                2.13%
+::deserialize_any                                2.13%
+::write                                          2.12%
+libc.so.6`malloc_consolidate                     2.02%
+```
+
+Interpretation:
+
+- The full-thread profile was heavily affected by glibc allocator contention.
+- Reducing Rayon parallelism makes the workload characteristics clearer: the
+  remaining major work is CityJSON parsing/reading, GLB/glTF output, PROJ work,
+  and normal allocation/free cost.
+- The workload is not scaling cleanly with the original thread count, because
+  many threads contend on the allocator while processing allocation-heavy
+  feature/model data.
+- A different allocator (`jemalloc` or `mimalloc`) is now a strong whole-run
+  experiment, because it may recover parallelism without forcing the Rayon
+  thread count down.
+- `selected_geometry_stats` still shows the same local pattern: 85.05% of its
+  visible samples are `RawVec` growth/reserve and 83.21% contain malloc/realloc.
+  The absolute share is lower because the profile is no longer dominated by
+  allocator lock stalls.
+
+## Most Likely Stage-Specific Problem
+
+The current implementation always computes a full `CellCounts` object before
+deciding whether the feature has unique cell assignment.
+
+For `Building` and `BuildingPart`, `feature_to_cells` assigns the feature to
+exactly one grid cell: the cell with the highest score.
+
+However, before that max is taken, `count_vertices_in_grid` calls
+`CellCounts::merge_vertex_counts_with_bbox`, which enumerates every grid cell
+intersecting the feature bbox and materializes scores for all of them.
+
+For building-like unique assignment, this can be wasteful:
+
+- bbox-only cells are generated,
+- `Vec` capacity is sized for the bbox intersection,
+- all entries are iterated again to find the max,
+- all non-max entries are then discarded.
+
+This is especially suspicious for real input with millions of features, because
+even a small per-feature bbox expansion cost scales directly with feature count.
+Large or elongated feature bboxes can make it much worse.
+
+The first buildings-only profile strengthens this recommendation. For
+`Building`/`BuildingPart`, the code path currently builds and frees several
+temporary containers per feature:
+
+- `selected_vertices` inside `selected_geometry_stats`,
+- a `BTreeMap<CellId, usize>` in `count_vertex_cells`,
+- a `Vec<(CellId, usize)>` conversion before bbox merging,
+- a `CellCounts` vector including bbox-only cells,
+- a final `Vec<(CellId, Cell)>` in `feature_to_cells`.
+
+For unique assignment, most of this data is only used to select one maximum
+cell. The highest-value optimization is therefore to collapse the unique path
+into a single pass that returns the best cell directly.
+
+The third profile adds a more precise first target: the empty `Vec` allocations
+inside `selected_geometry_stats` are repeatedly growing. Before changing
+ownership semantics, reduce this churn by pre-sizing or reusing the temporary
+vertex buffers used to collect unique vertex indices.
+
+## Current Score Semantics
+
+The counting code has a non-obvious `or_insert(1) += 1` pattern.
+
+For a vertex in a previously unseen cell:
+
+```rust
+*vertex_counts.entry(cellid).or_insert(1) += 1;
+```
+
+The first vertex produces a score of `2`, not `1`.
+
+Then bbox merging adds another point:
+
+- vertex cell inside bbox: `count + 1`
+- bbox-only cell: `2`
+
+The tests currently encode this behavior. It should be preserved unless the
+ownership scoring semantics are intentionally changed.
+
+## Recommended Optimization
+
+There are two related optimizations.
+
+First, reduce `selected_geometry_stats` allocation churn:
+
+1. Initialize `selected_vertices` with a capacity derived from
+   `model.vertices().len()`.
+2. Initialize `geometry_scratch` with a capacity derived from the same source or
+   from a conservative per-geometry estimate.
+3. Keep the existing `sort_unstable` and `dedup` behavior, because sorting is
+   only a small part of the current visible cost and it preserves exact centroid
+   and bbox semantics.
+
+Then split the unique-assignment path before full bbox-cell materialization.
+
+For `Building` and `BuildingPart`:
+
+1. Compute selected geometry stats as today.
+2. Count selected vertices by located grid cell.
+3. Pick the max-score cell directly.
+4. Preserve deterministic tie-breaking.
+5. Return only that one `(CellId, Cell)` assignment.
+6. Skip `CellCounts::merge_vertex_counts_with_bbox`.
+
+More aggressive version:
+
+1. Detect unique assignment before `count_vertices_in_grid`.
+2. For unique assignment, do not create `CellCounts`.
+3. If selected vertex cells exist, choose the best vertex cell directly.
+4. Only consult bbox cells if the current semantics require a fallback for an
+   otherwise empty vertex-cell map.
+
+This preserves the current practical output for ordinary building features
+where selected vertices exist, while avoiding materializing bbox-only cells that
+are discarded immediately.
+
+Expected benefit:
+
+- reduces per-building allocations,
+- reduces `BTreeMap` or replacement map mutations,
+- removes bbox-range enumeration for unique assignment,
+- should scale well on the 11 million feature input if buildings dominate.
+
+Expected evidence after implementation:
+
+- fewer `cfree`, `_int_free`, `malloc`, and `malloc_consolidate` samples,
+- fewer `native_queued_spin_lock_slowpath` samples caused by allocator locks,
+- lower time in the logged `Counting vertices in grid cells` stage,
+- no meaningful change in projection or JSON parsing costs.
+
+## Tie-Breaking
+
+Current unique assignment uses:
+
+```rust
+cell_vtx_cnt.iter().max_by(|a, b| a.1.cmp(b.1))
+```
+
+Rust iterator `max_by` returns the last maximum for equal comparisons. Since
+`CellCounts` entries are sorted by `CellId`, equal scores currently select the
+greatest `CellId` among tied cells.
+
+Any optimized path should preserve that behavior unless intentionally changed.
+
+## Instrumentation Needed In Next Run
+
+Add timing logs inside `World::index_with_grid` around:
+
+- page scan / model loading,
+- `selected_geometry_stats`,
+- vertex-cell counting,
+- bbox-cell merge,
+- unique assignment max selection,
+- `integrate_feature_in_cells`,
+- page-level total.
+
+Also log counters:
+
+- number of features processed,
+- selected vertex count histogram or buckets,
+- bbox-intersecting cell count histogram or buckets,
+- number of unique-assignment vs multi-cell-assignment features,
+- number of large-feature parallel-path calls.
+
+This will make the next buildings run actionable even if collapsed stacks still
+lose some Rust call-path detail.
+
+## Longer-Term Direction
+
+`docs/adr/001-use-segment-grid-traversal-for-feature-cell-ownership.md` already
+accepts replacing bbox fallback with segment-to-grid traversal.
+
+That is the better semantic fix for ownership scoring. It avoids bbox inflation
+and derives candidate cells from actual geometry coverage. However, it is a
+larger implementation than the direct unique-assignment optimization.
+
+Recommended order:
+
+1. Add timing instrumentation.
+2. Optimize unique-assignment buildings by avoiding full bbox-cell
+   materialization.
+3. Re-profile the buildings-only run.
+4. Implement segment-to-grid traversal if ownership quality or bbox overhead
+   still matters after step 2.
+
+## Test Plan For The Optimization
+
+Add tests for the unique-assignment fast path:
+
+- one vertex cell,
+- multiple vertex cells with different counts,
+- equal-count tie cells,
+- large bbox with many bbox-only cells,
+- behavior parity with current unique assignment for representative building
+  features.
+
+Keep existing `count_vertices_in_grid_*` tests for the multi-cell path.
+
+Run:
+
+```bash
+cargo test
+```

--- a/docs/performance/runs/.gitignore
+++ b/docs/performance/runs/.gitignore
@@ -1,0 +1,1 @@
+.tyler-profile-staging.*

--- a/docs/performance/runs/README.md
+++ b/docs/performance/runs/README.md
@@ -31,14 +31,19 @@ object with a `tyler_args` array and an optional `env` object. Example:
 Each run gets its own subdirectory containing:
 
 - `manifest.json`
-- `perf-stat.json`
-- `massif-summary.json`
+- `perf-stat.json` when `--runner perf` or `--runner all` is used
+- `massif-summary.json` when `--runner massif` or `--runner all` is used
 - `summary.md`
 
 Raw `perf stat` and Valgrind Massif dumps are written to a temporary staging
 area and are not meant to be committed.
 Tyler's own output is also written to that staging area while the profiler is
 running and is deleted before the final run directory is moved into place.
+If a profiling run fails, the staging directory is preserved as a
+`<run-id>.failed/` directory in this tree so you can inspect partial results
+without rerunning Massif.
 
 You can still override the input path manually with the script flags when you
 need an ad hoc run, but the Geodepot profile mode is the default workflow.
+The default runner mode is `all`; use `--runner perf` or `--runner massif`
+when you only want one profiler.

--- a/docs/performance/runs/README.md
+++ b/docs/performance/runs/README.md
@@ -1,0 +1,44 @@
+# Profiling Runs
+
+This directory stores committed per-run profiling summaries produced by
+`just profile`.
+
+The profiling wrapper now runs in profile-by-name mode. It resolves the input
+dataset through Geodepot and reads the matching tyler arguments from the
+`profile-tyler.json` data item stored at the case root. For example, the case
+spec `bvz-dh-coast-5/bvz_dh` uses `bvz-dh-coast-5/profile-tyler.json` for the
+profile data item. The Geodepot executable path is read from the repo-local
+`.env` file via `GEODEPOT_BIN`.
+
+The profile item should contain a JSON array of `tyler` arguments, or a JSON
+object with a `tyler_args` array and an optional `env` object. Example:
+
+```json
+{
+  "tyler_args": [
+    "--3dtiles-implicit",
+    "--object-type",
+    "Building",
+    "--object-type",
+    "BuildingPart"
+  ],
+  "env": {
+    "RUST_LOG": "info"
+  }
+}
+```
+
+Each run gets its own subdirectory containing:
+
+- `manifest.json`
+- `perf-stat.json`
+- `massif-summary.json`
+- `summary.md`
+
+Raw `perf stat` and Valgrind Massif dumps are written to a temporary staging
+area and are not meant to be committed.
+Tyler's own output is also written to that staging area while the profiler is
+running and is deleted before the final run directory is moved into place.
+
+You can still override the input path manually with the script flags when you
+need an ad hoc run, but the Geodepot profile mode is the default workflow.

--- a/justfile
+++ b/justfile
@@ -11,6 +11,10 @@ check:
 build *args:
     cargo build --workspace --all-targets --all-features {{args}}
 
+# Run a perf + Massif profiling session for tyler.
+profile *args:
+    @bash scripts/profile-tyler.sh {{args}}
+
 # Run clippy with strict lint settings across the workspace.
 lint:
     RUSTFLAGS='-Dclippy::all -Dclippy::pedantic' RUSTC_WORKSPACE_WRAPPER="$(command -v clippy-driver)" cargo check --workspace --all-targets --all-features

--- a/scripts/profile-tyler.sh
+++ b/scripts/profile-tyler.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 readonly DEFAULT_OUTPUT_ROOT="docs/performance/runs"
 readonly DEFAULT_GEODEPOT_ENV_FILE=".env"
+readonly DEFAULT_RUNNER="all"
 readonly PROFILE_CONFIG_BASENAME="profile-tyler.json"
 readonly PROFILE_CONFIG_TYPO_BASENAME="profile-tiler.json"
 readonly RUSTFLAGS_VALUE="-C debuginfo=2 -C force-frame-pointers=yes"
@@ -16,10 +17,11 @@ die() {
 
 usage() {
     cat <<'EOF'
-Usage: profile-tyler.sh [--profile CASESPEC] [--input PATH] [--label LABEL] [--output-root DIR]
+Usage: profile-tyler.sh [--profile CASESPEC] [--input PATH] [--label LABEL] [--output-root DIR] [--runner MODE]
 
 Defaults:
   --output-root docs/performance/runs
+  --runner      all
   .env          Provides GEODEPOT_BIN for profile resolution
 
 Parameters:
@@ -30,6 +32,8 @@ Parameters:
   --input PATH     Dataset root to profile. Must be an existing tyler input root.
   --label LABEL    Optional run label appended to the run directory name.
   --output-root DIR  Directory that receives the per-run profiling artifacts.
+  --runner MODE    Select which profiler(s) to run: perf, massif, all, or
+                   none. The default is all.
 
 The script builds tyler in release mode with debuginfo and frame pointers,
 then captures perf stat and Valgrind Massif summaries into a new run directory.
@@ -40,6 +44,9 @@ is removed before the final run directory is published.
 
 Examples:
   just profile -- --profile bvz-dh-coast-5/bvz_dh
+  just profile -- --profile bvz-dh-coast-5/bvz_dh --runner perf
+  just profile -- --profile bvz-dh-coast-5/bvz_dh --runner massif
+  just profile -- --profile bvz-dh-coast-5/bvz_dh --runner none
   just profile -- --profile bvz-dh-coast-5/bvz_dh --output-root docs/performance/runs
   just profile -- --input /data/cases/demo --label manual-smoke
 EOF
@@ -160,6 +167,7 @@ profile_spec=""
 profile_input_root=""
 run_label=""
 output_root="$DEFAULT_OUTPUT_ROOT"
+runner_selector="$DEFAULT_RUNNER"
 
 while (($#)); do
     case "$1" in
@@ -187,6 +195,11 @@ while (($#)); do
             output_root="$2"
             shift 2
             ;;
+        --runner)
+            [[ $# -ge 2 ]] || die "--runner requires a value"
+            runner_selector="$2"
+            shift 2
+            ;;
         --)
             shift
             continue
@@ -209,11 +222,35 @@ if [[ -n "$profile_spec" && -n "$run_label" ]]; then
     die "--profile cannot be combined with --label"
 fi
 
+run_perf="false"
+run_massif="false"
+case "$runner_selector" in
+    all)
+        run_perf="true"
+        run_massif="true"
+        ;;
+    perf)
+        run_perf="true"
+        ;;
+    massif)
+        run_massif="true"
+        ;;
+    none)
+        ;;
+    *)
+        die "invalid --runner value: $runner_selector (expected perf, massif, all, or none)"
+        ;;
+esac
+
 require_tool cargo
 require_tool git
 require_tool jq
-require_tool perf
-require_tool valgrind
+if [[ "$run_perf" == "true" ]]; then
+    require_tool perf
+fi
+if [[ "$run_massif" == "true" ]]; then
+    require_tool valgrind
+fi
 
 script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
 repo_root="$(cd "$script_dir/.." && pwd -P)"
@@ -323,9 +360,37 @@ final_run_dir="$output_root/$run_id"
 
 staging_dir="$(mktemp -d "$output_root/.tyler-profile-staging.XXXXXX")"
 finalized="false"
+failed_run_dir=""
 cleanup() {
-    if [[ "$finalized" != "true" && -d "$staging_dir" ]]; then
+    local exit_status="$?"
+    local target_dir
+    if [[ "$finalized" == "true" || ! -d "$staging_dir" ]]; then
+        return 0
+    fi
+
+    if [[ "$exit_status" -eq 0 ]]; then
         rm -rf "$staging_dir"
+        return 0
+    fi
+
+    target_dir="$final_run_dir.failed"
+    if [[ -e "$target_dir" ]]; then
+        target_dir="${target_dir}.$(date -u +%Y-%m-%dT%H-%M-%S-%NZ)"
+    fi
+
+    failed_run_dir="$target_dir"
+    {
+        printf 'run_id=%s\n' "$run_id"
+        printf 'created_at=%s\n' "$created_at"
+        printf 'runner=%s\n' "$runner_selector"
+        printf 'exit_status=%s\n' "$exit_status"
+    } > "$staging_dir/FAILED.txt"
+
+    if mv "$staging_dir" "$target_dir"; then
+        printf 'Preserved failed profiling run in %s\n' "$target_dir" >&2
+    else
+        printf 'warning: failed profiling run could not be moved to %s; staging remains at %s\n' \
+            "$target_dir" "$staging_dir" >&2
     fi
 }
 trap cleanup EXIT
@@ -345,178 +410,235 @@ printf 'Building profiling binary...\n'
 
 perf_output_dir="$tyler_output_base/perf"
 massif_output_dir="$tyler_output_base/massif"
-mkdir -p "$perf_output_dir" "$massif_output_dir"
-
-perf_raw_json="$staging_dir/perf-stat.raw.json"
-perf_stderr="$staging_dir/perf-stat.stderr.log"
-tyler_perf_command=("$binary_path" "$input_root")
-tyler_perf_command+=( "${profile_tyler_args[@]}" )
-tyler_perf_command+=( --output "$perf_output_dir" )
-perf_command=(perf stat -j -e "$PERF_EVENTS" -o "$perf_raw_json" -- "${tyler_perf_command[@]}")
-
-printf 'Running perf stat...\n'
-printf 'Tyler command: ' >&2
-print_command "${tyler_perf_command[@]}" >&2
-perf_start_ns="$(date +%s%N)"
-set +e
-"${perf_command[@]}" > /dev/null 2> "$perf_stderr"
-perf_status="$?"
-set -e
-perf_end_ns="$(date +%s%N)"
-perf_elapsed_seconds="$(awk -v start="$perf_start_ns" -v end="$perf_end_ns" 'BEGIN { printf "%.6f", (end - start) / 1000000000 }')"
-if [[ "$perf_status" -ne 0 ]]; then
-    die "perf run failed with exit status $perf_status; see $perf_stderr"
+if [[ "$run_perf" == "true" ]]; then
+    mkdir -p "$perf_output_dir"
+fi
+if [[ "$run_massif" == "true" ]]; then
+    mkdir -p "$massif_output_dir"
 fi
 
-perf_summary_json="$staging_dir/perf-stat.json"
-jq -s \
-    --arg wall_clock_seconds "$perf_elapsed_seconds" \
+perf_elapsed_seconds=""
+perf_cycles=""
+perf_instructions=""
+perf_cache_refs=""
+perf_cache_misses=""
+perf_page_faults=""
+perf_context_switches=""
+perf_cpu_migrations=""
+perf_branches=""
+perf_branch_misses=""
+perf_raw_json=""
+perf_stderr=""
+perf_summary_json=""
+tyler_perf_command=()
+perf_command=()
+
+if [[ "$run_perf" == "true" ]]; then
+    perf_raw_json="$staging_dir/perf-stat.raw.json"
+    perf_stderr="$staging_dir/perf-stat.stderr.log"
+    tyler_perf_command=("$binary_path" "$input_root")
+    tyler_perf_command+=( "${profile_tyler_args[@]}" )
+    tyler_perf_command+=( --output "$perf_output_dir" )
+    perf_command=(perf stat -j -e "$PERF_EVENTS" -o "$perf_raw_json" -- "${tyler_perf_command[@]}")
+
+    printf 'Running perf stat...\n'
+    printf 'Tyler command: ' >&2
+    print_command "${tyler_perf_command[@]}" >&2
+    perf_start_ns="$(date +%s%N)"
+    set +e
+    "${perf_command[@]}" > /dev/null 2> "$perf_stderr"
+    perf_status="$?"
+    set -e
+    perf_end_ns="$(date +%s%N)"
+    perf_elapsed_seconds="$(awk -v start="$perf_start_ns" -v end="$perf_end_ns" 'BEGIN { printf "%.6f", (end - start) / 1000000000 }')"
+    if [[ "$perf_status" -ne 0 ]]; then
+        die "perf run failed with exit status $perf_status; see $perf_stderr"
+    fi
+
+    perf_summary_json="$staging_dir/perf-stat.json"
+    perf_summary_filter='
+        def event_value($name):
+            ([.[] | select(.event == $name)] | first)."counter-value" | tonumber;
+        def ratio($numerator; $denominator):
+            if $denominator == 0 then null else ($numerator / $denominator) end;
+        {
+            wall_clock_seconds: ($wall_clock_seconds | tonumber),
+            counters: {
+                cycles: event_value("cycles"),
+                instructions: event_value("instructions"),
+                instructions_per_cycle: ratio(event_value("instructions"); event_value("cycles")),
+                cache_references: event_value("cache-references"),
+                cache_misses: event_value("cache-misses"),
+                cache_miss_rate: ratio(event_value("cache-misses"); event_value("cache-references")),
+                page_faults: event_value("page-faults"),
+                context_switches: event_value("context-switches"),
+                cpu_migrations: event_value("cpu-migrations"),
+                branches: event_value("branches"),
+                branch_misses: event_value("branch-misses")
+            },
+            raw_events: .
+        }
     '
-    def event_value($name):
-        ([.[] | select(.event == $name)] | first)."counter-value" | tonumber;
-    def ratio($numerator; $denominator):
-        if $denominator == 0 then null else ($numerator / $denominator) end;
-    {
-        wall_clock_seconds: ($wall_clock_seconds | tonumber),
-        counters: {
-            cycles: event_value("cycles"),
-            instructions: event_value("instructions"),
-            instructions_per_cycle: ratio(event_value("instructions"); event_value("cycles")),
-            cache_references: event_value("cache-references"),
-            cache_misses: event_value("cache-misses"),
-            cache_miss_rate: ratio(event_value("cache-misses"); event_value("cache-references")),
-            page_faults: event_value("page-faults"),
-            context_switches: event_value("context-switches"),
-            cpu_migrations: event_value("cpu-migrations"),
-            branches: event_value("branches"),
-            branch_misses: event_value("branch-misses")
-        },
-        raw_events: .
-    }
-    ' "$perf_raw_json" > "$perf_summary_json"
+    jq -s \
+        --arg wall_clock_seconds "$perf_elapsed_seconds" \
+        "$perf_summary_filter" "$perf_raw_json" > "$perf_summary_json"
 
-perf_cycles="$(jq -r '.counters.cycles' "$perf_summary_json")"
-perf_instructions="$(jq -r '.counters.instructions' "$perf_summary_json")"
-perf_cache_refs="$(jq -r '.counters.cache_references' "$perf_summary_json")"
-perf_cache_misses="$(jq -r '.counters.cache_misses' "$perf_summary_json")"
-perf_page_faults="$(jq -r '.counters.page_faults' "$perf_summary_json")"
-perf_context_switches="$(jq -r '.counters.context_switches' "$perf_summary_json")"
-perf_cpu_migrations="$(jq -r '.counters.cpu_migrations' "$perf_summary_json")"
-perf_branches="$(jq -r '.counters.branches' "$perf_summary_json")"
-perf_branch_misses="$(jq -r '.counters.branch_misses' "$perf_summary_json")"
-
-massif_raw="$staging_dir/massif.out"
-massif_stdout="$staging_dir/massif.stdout.log"
-massif_stderr="$staging_dir/massif.stderr.log"
-tyler_massif_command=("$binary_path" "$input_root")
-tyler_massif_command+=( "${profile_tyler_args[@]}" )
-tyler_massif_command+=( --output "$massif_output_dir" )
-massif_command=(valgrind --tool=massif --time-unit="$MASSIF_TIME_UNIT" --massif-out-file="$massif_raw" -- "${tyler_massif_command[@]}")
-
-printf 'Running Massif...\n'
-printf 'Tyler command: ' >&2
-print_command "${tyler_massif_command[@]}" >&2
-massif_start_ns="$(date +%s%N)"
-set +e
-"${massif_command[@]}" > "$massif_stdout" 2> "$massif_stderr"
-massif_status="$?"
-set -e
-massif_end_ns="$(date +%s%N)"
-massif_elapsed_seconds="$(awk -v start="$massif_start_ns" -v end="$massif_end_ns" 'BEGIN { printf "%.6f", (end - start) / 1000000000 }')"
-if [[ "$massif_status" -ne 0 ]]; then
-    die "Massif run failed with exit status $massif_status; see $massif_stderr"
+    perf_cycles="$(jq -r '.counters.cycles' "$perf_summary_json")"
+    perf_instructions="$(jq -r '.counters.instructions' "$perf_summary_json")"
+    perf_cache_refs="$(jq -r '.counters.cache_references' "$perf_summary_json")"
+    perf_cache_misses="$(jq -r '.counters.cache_misses' "$perf_summary_json")"
+    perf_page_faults="$(jq -r '.counters.page_faults' "$perf_summary_json")"
+    perf_context_switches="$(jq -r '.counters.context_switches' "$perf_summary_json")"
+    perf_cpu_migrations="$(jq -r '.counters.cpu_migrations' "$perf_summary_json")"
+    perf_branches="$(jq -r '.counters.branches' "$perf_summary_json")"
+    perf_branch_misses="$(jq -r '.counters.branch_misses' "$perf_summary_json")"
+else
+    printf 'Skipping perf stat (runner=%s)\n' "$runner_selector"
 fi
 
-read -r peak_heap_bytes peak_snapshot peak_time snapshot_count max_heap_growth_bytes max_heap_growth_from_snapshot max_heap_growth_to_snapshot max_heap_growth_time < <(
-    awk '
-        BEGIN {
-            snapshot = -1;
-            time = 0;
-            peak_heap = -1;
-            peak_snapshot = -1;
-            peak_time = 0;
-            snapshot_count = 0;
-            max_heap_growth = -1;
-            max_from = -1;
-            max_to = -1;
-            max_growth_time = 0;
-            prev_heap = -1;
-            prev_snapshot = -1;
-        }
-        /^snapshot=/ {
-            snapshot = substr($0, 10) + 0;
-            snapshot_count += 1;
-            next;
-        }
-        /^time=/ {
-            time = substr($0, 6) + 0;
-            next;
-        }
-        /^mem_heap_B=/ {
-            heap = substr($0, 12) + 0;
-            if (heap > peak_heap) {
-                peak_heap = heap;
-                peak_snapshot = snapshot;
-                peak_time = time;
-            }
-            if (prev_heap >= 0) {
-                growth = heap - prev_heap;
-                if (growth > max_heap_growth) {
-                    max_heap_growth = growth;
-                    max_from = prev_snapshot;
-                    max_to = snapshot;
-                    max_growth_time = time;
-                }
-            }
-            prev_heap = heap;
-            prev_snapshot = snapshot;
-            next;
-        }
-        END {
-            if (peak_heap < 0) {
-                peak_heap = 0;
-                peak_snapshot = 0;
+massif_elapsed_seconds=""
+peak_heap_bytes=""
+peak_snapshot=""
+peak_time=""
+snapshot_count=""
+max_heap_growth_bytes=""
+max_heap_growth_from_snapshot=""
+max_heap_growth_to_snapshot=""
+max_heap_growth_time=""
+massif_raw=""
+massif_stdout=""
+massif_stderr=""
+massif_summary_json=""
+tyler_massif_command=()
+massif_command=()
+
+if [[ "$run_massif" == "true" ]]; then
+    massif_raw="$staging_dir/massif.out"
+    massif_stdout="$staging_dir/massif.stdout.log"
+    massif_stderr="$staging_dir/massif.stderr.log"
+    tyler_massif_command=("$binary_path" "$input_root")
+    tyler_massif_command+=( "${profile_tyler_args[@]}" )
+    tyler_massif_command+=( --output "$massif_output_dir" )
+    massif_command=(valgrind --tool=massif --time-unit="$MASSIF_TIME_UNIT" --massif-out-file="$massif_raw" -- "${tyler_massif_command[@]}")
+
+    printf 'Running Massif...\n'
+    printf 'Tyler command: ' >&2
+    print_command "${tyler_massif_command[@]}" >&2
+    massif_start_ns="$(date +%s%N)"
+    set +e
+    "${massif_command[@]}" > "$massif_stdout" 2> "$massif_stderr"
+    massif_status="$?"
+    set -e
+    massif_end_ns="$(date +%s%N)"
+    massif_elapsed_seconds="$(awk -v start="$massif_start_ns" -v end="$massif_end_ns" 'BEGIN { printf "%.6f", (end - start) / 1000000000 }')"
+    if [[ "$massif_status" -ne 0 ]]; then
+        die "Massif run failed with exit status $massif_status; see $massif_stderr"
+    fi
+
+    read -r peak_heap_bytes peak_snapshot peak_time snapshot_count max_heap_growth_bytes max_heap_growth_from_snapshot max_heap_growth_to_snapshot max_heap_growth_time < <(
+        awk '
+            BEGIN {
+                snapshot = -1;
+                time = 0;
+                peak_heap = -1;
+                peak_snapshot = -1;
                 peak_time = 0;
-            }
-            if (max_heap_growth < 0) {
-                max_heap_growth = 0;
-                max_from = 0;
-                max_to = 0;
+                snapshot_count = 0;
+                max_heap_growth = -1;
+                max_from = -1;
+                max_to = -1;
                 max_growth_time = 0;
+                prev_heap = -1;
+                prev_snapshot = -1;
             }
-            printf "%s %s %s %s %s %s %s %s\n", peak_heap, peak_snapshot, peak_time, snapshot_count, max_heap_growth, max_from, max_to, max_growth_time;
+            /^snapshot=/ {
+                snapshot = substr($0, 10) + 0;
+                snapshot_count += 1;
+                next;
+            }
+            /^time=/ {
+                time = substr($0, 6) + 0;
+                next;
+            }
+            /^mem_heap_B=/ {
+                heap = substr($0, 12) + 0;
+                if (heap > peak_heap) {
+                    peak_heap = heap;
+                    peak_snapshot = snapshot;
+                    peak_time = time;
+                }
+                if (prev_heap >= 0) {
+                    growth = heap - prev_heap;
+                    if (growth > max_heap_growth) {
+                        max_heap_growth = growth;
+                        max_from = prev_snapshot;
+                        max_to = snapshot;
+                        max_growth_time = time;
+                    }
+                }
+                prev_heap = heap;
+                prev_snapshot = snapshot;
+                next;
+            }
+            END {
+                if (peak_heap < 0) {
+                    peak_heap = 0;
+                    peak_snapshot = 0;
+                    peak_time = 0;
+                }
+                if (max_heap_growth < 0) {
+                    max_heap_growth = 0;
+                    max_from = 0;
+                    max_to = 0;
+                    max_growth_time = 0;
+                }
+                printf "%s %s %s %s %s %s %s %s\n", peak_heap, peak_snapshot, peak_time, snapshot_count, max_heap_growth, max_from, max_to, max_growth_time;
+            }
+        ' "$massif_raw"
+    )
+
+    massif_summary_json="$staging_dir/massif-summary.json"
+    massif_summary_filter='
+        {
+            time_unit: $time_unit,
+            peak_heap_bytes: $peak_heap_bytes,
+            peak_heap_mib: ($peak_heap_bytes / 1048576),
+            peak_snapshot: $peak_snapshot,
+            peak_time: $peak_time,
+            snapshot_count: $snapshot_count,
+            max_heap_growth_bytes: $max_heap_growth_bytes,
+            max_heap_growth_from_snapshot: $max_heap_growth_from_snapshot,
+            max_heap_growth_to_snapshot: $max_heap_growth_to_snapshot,
+            max_heap_growth_time: $max_heap_growth_time
         }
-    ' "$massif_raw"
-)
+    '
+    jq -n \
+        --arg time_unit "$MASSIF_TIME_UNIT" \
+        --argjson peak_heap_bytes "$peak_heap_bytes" \
+        --argjson peak_snapshot "$peak_snapshot" \
+        --argjson peak_time "$peak_time" \
+        --argjson snapshot_count "$snapshot_count" \
+        --argjson max_heap_growth_bytes "$max_heap_growth_bytes" \
+        --argjson max_heap_growth_from_snapshot "$max_heap_growth_from_snapshot" \
+        --argjson max_heap_growth_to_snapshot "$max_heap_growth_to_snapshot" \
+        --argjson max_heap_growth_time "$max_heap_growth_time" \
+        "$massif_summary_filter" > "$massif_summary_json"
+else
+    printf 'Skipping Massif (runner=%s)\n' "$runner_selector"
+fi
 
-massif_summary_json="$staging_dir/massif-summary.json"
-jq -n \
-    --arg time_unit "$MASSIF_TIME_UNIT" \
-    --argjson peak_heap_bytes "$peak_heap_bytes" \
-    --argjson peak_snapshot "$peak_snapshot" \
-    --argjson peak_time "$peak_time" \
-    --argjson snapshot_count "$snapshot_count" \
-    --argjson max_heap_growth_bytes "$max_heap_growth_bytes" \
-    --argjson max_heap_growth_from_snapshot "$max_heap_growth_from_snapshot" \
-    --argjson max_heap_growth_to_snapshot "$max_heap_growth_to_snapshot" \
-    --argjson max_heap_growth_time "$max_heap_growth_time" \
-    '{
-        time_unit: $time_unit,
-        peak_heap_bytes: $peak_heap_bytes,
-        peak_heap_mib: ($peak_heap_bytes / 1048576),
-        peak_snapshot: $peak_snapshot,
-        peak_time: $peak_time,
-        snapshot_count: $snapshot_count,
-        max_heap_growth_bytes: $max_heap_growth_bytes,
-        max_heap_growth_from_snapshot: $max_heap_growth_from_snapshot,
-        max_heap_growth_to_snapshot: $max_heap_growth_to_snapshot,
-        max_heap_growth_time: $max_heap_growth_time
-    }' > "$massif_summary_json"
-
-peak_heap_mib="$(format_mib "$peak_heap_bytes")"
-max_heap_growth_mib="$(format_mib "$max_heap_growth_bytes")"
-perf_cache_miss_rate_display="$(format_ratio "$perf_cache_misses" "$perf_cache_refs")"
-perf_ipc_display="$(format_ratio "$perf_instructions" "$perf_cycles")"
+peak_heap_mib="n/a"
+max_heap_growth_mib="n/a"
+perf_cache_miss_rate_display="n/a"
+perf_ipc_display="n/a"
+if [[ "$run_massif" == "true" ]]; then
+    peak_heap_mib="$(format_mib "$peak_heap_bytes")"
+    max_heap_growth_mib="$(format_mib "$max_heap_growth_bytes")"
+fi
+if [[ "$run_perf" == "true" ]]; then
+    perf_cache_miss_rate_display="$(format_ratio "$perf_cache_misses" "$perf_cache_refs")"
+    perf_ipc_display="$(format_ratio "$perf_instructions" "$perf_cycles")"
+fi
 
 manifest_json="$staging_dir/manifest.json"
 jq_profile_tyler_args="$(json_array_from_args "${profile_tyler_args[@]}")"
@@ -538,6 +660,7 @@ jq -n \
     --arg output_root "$output_root" \
     --arg staging_dir "$staging_dir" \
     --arg run_dir "$final_run_dir" \
+    --arg runner_selector "$runner_selector" \
     --arg binary_path "$binary_path" \
     --arg geodepot_bin "${geodepot_bin:-}" \
     --arg git_sha "$git_sha" \
@@ -557,6 +680,10 @@ jq -n \
     --arg perf_raw_json "$perf_raw_json" \
     --arg massif_raw "$massif_raw" \
     --arg manifest_path "$repo_root/Cargo.toml" \
+    --argjson run_perf "$(json_bool "$run_perf")" \
+    --argjson run_massif "$(json_bool "$run_massif")" \
+    --argjson jq_perf_command "$jq_perf_command" \
+    --argjson jq_massif_command "$jq_massif_command" \
     --argjson tyler_perf_command "$jq_tyler_perf_command" \
     --argjson tyler_massif_command "$jq_tyler_massif_command" \
     '
@@ -564,6 +691,11 @@ jq -n \
         run_id: $run_id,
         run_label: (if $run_label == "" then null else $run_label end),
         created_at: $created_at,
+        runner: {
+            selector: $runner_selector,
+            perf: $run_perf,
+            massif: $run_massif
+        },
         profile: {
             spec: (if $profile_spec == "" then null else $profile_spec end),
             resolved_input_root: (if $profile_input_root == "" then null else $profile_input_root end),
@@ -603,31 +735,39 @@ jq -n \
             rustflags: $rustflags
         },
         perf: {
-            command: $jq_perf_command,
-            tyler_command: $tyler_perf_command,
-            wall_clock_seconds: ($perf_elapsed_seconds | tonumber)
+            enabled: $run_perf,
+            command: (if $run_perf then $jq_perf_command else null end),
+            tyler_command: (if $run_perf then $tyler_perf_command else null end),
+            wall_clock_seconds: (if $run_perf then ($perf_elapsed_seconds | tonumber) else null end)
         },
         massif: {
-            command: $jq_massif_command,
-            tyler_command: $tyler_massif_command,
-            wall_clock_seconds: ($massif_elapsed_seconds | tonumber)
+            enabled: $run_massif,
+            command: (if $run_massif then $jq_massif_command else null end),
+            tyler_command: (if $run_massif then $tyler_massif_command else null end),
+            wall_clock_seconds: (if $run_massif then ($massif_elapsed_seconds | tonumber) else null end)
         }
     }
     ' > "$manifest_json"
 
-cat > "$staging_dir/summary.md" <<EOF
+{
+    cat <<EOF
 # Tyler profiling run
 
 - Run ID: $run_id
 - Git SHA: $git_sha
 - Branch: $git_branch
 - Created: $created_at
+- Runner: $runner_selector
 - Geodepot profile: ${profile_spec:-manual}
 - Geodepot input: ${profile_input_root:-n/a}
 - Profile config: ${profile_file:-n/a}
 - Input: $input_root
 - Output directory: $final_run_dir
 - Binary: $binary_path
+EOF
+
+    if [[ "$run_perf" == "true" ]]; then
+        cat <<EOF
 - Perf wall clock: ${perf_elapsed_seconds}s
 - Perf IPC: ${perf_ipc_display}
 - Perf cache references: $perf_cache_refs
@@ -638,17 +778,43 @@ cat > "$staging_dir/summary.md" <<EOF
 - Perf CPU migrations: $perf_cpu_migrations
 - Perf branches: $perf_branches
 - Perf branch misses: $perf_branch_misses
+EOF
+    else
+        cat <<EOF
+- Perf: skipped by --runner=$runner_selector
+EOF
+    fi
+
+    if [[ "$run_massif" == "true" ]]; then
+        cat <<EOF
 - Massif wall clock: ${massif_elapsed_seconds}s
 - Massif peak heap: ${peak_heap_mib} MiB (${peak_heap_bytes} bytes)
 - Massif peak snapshot: $peak_snapshot
 - Massif snapshots: $snapshot_count
 - Massif max heap growth: ${max_heap_growth_mib} MiB (${max_heap_growth_bytes} bytes)
 - Massif max heap growth snapshots: $max_heap_growth_from_snapshot -> $max_heap_growth_to_snapshot
+EOF
+    else
+        cat <<EOF
+- Massif: skipped by --runner=$runner_selector
+EOF
+    fi
+
+    cat <<EOF
 
 Committed artifacts are the JSON summaries and this markdown note. Raw perf and Massif dumps are staged only while the profiler runs.
 EOF
+} > "$staging_dir/summary.md"
 
-rm -rf "$tyler_output_base" "$perf_raw_json" "$perf_stderr" "$massif_raw" "$massif_stdout" "$massif_stderr"
+remove_paths() {
+    local path
+    for path in "$@"; do
+        [[ -n "$path" ]] || continue
+        rm -rf "$path"
+    done
+}
+
+remove_paths "$tyler_output_base" "$perf_raw_json" "$perf_stderr" "$massif_raw" "$massif_stdout" "$massif_stderr"
 
 mv "$staging_dir" "$final_run_dir"
 finalized="true"

--- a/scripts/profile-tyler.sh
+++ b/scripts/profile-tyler.sh
@@ -1,0 +1,657 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly DEFAULT_OUTPUT_ROOT="docs/performance/runs"
+readonly DEFAULT_GEODEPOT_ENV_FILE=".env"
+readonly PROFILE_CONFIG_BASENAME="profile-tyler.json"
+readonly PROFILE_CONFIG_TYPO_BASENAME="profile-tiler.json"
+readonly RUSTFLAGS_VALUE="-C debuginfo=2 -C force-frame-pointers=yes"
+readonly PERF_EVENTS="cycles,instructions,cache-references,cache-misses,page-faults,context-switches,cpu-migrations,branches,branch-misses"
+readonly MASSIF_TIME_UNIT="B"
+
+die() {
+    printf 'error: %s\n' "$*" >&2
+    exit 1
+}
+
+usage() {
+    cat <<'EOF'
+Usage: profile-tyler.sh [--profile CASESPEC] [--input PATH] [--label LABEL] [--output-root DIR]
+
+Defaults:
+  --output-root docs/performance/runs
+  .env          Provides GEODEPOT_BIN for profile resolution
+
+Parameters:
+  -h, --help       Show this help text and exit.
+  --profile NAME   Geodepot case spec. The script resolves NAME to the input
+                   root and reads CASE/profile-tyler.json for tyler args,
+                   where CASE is the left side of the `/` separator.
+  --input PATH     Dataset root to profile. Must be an existing tyler input root.
+  --label LABEL    Optional run label appended to the run directory name.
+  --output-root DIR  Directory that receives the per-run profiling artifacts.
+
+The script builds tyler in release mode with debuginfo and frame pointers,
+then captures perf stat and Valgrind Massif summaries into a new run directory.
+When --profile is provided, the script reads the geodepot-resolved
+profile-tyler.json data item for the matching tyler command-line arguments.
+Tyler's own output is written into a temporary staging area while profiling and
+is removed before the final run directory is published.
+
+Examples:
+  just profile -- --profile bvz-dh-coast-5/bvz_dh
+  just profile -- --profile bvz-dh-coast-5/bvz_dh --output-root docs/performance/runs
+  just profile -- --input /data/cases/demo --label manual-smoke
+EOF
+}
+
+sanitize_label() {
+    local label="$1"
+    label="${label//[^A-Za-z0-9._-]/_}"
+    label="${label#_}"
+    label="${label%_}"
+    printf '%s' "${label:-run}"
+}
+
+require_tool() {
+    local tool="$1"
+    command -v "$tool" >/dev/null 2>&1 || die "required tool not found: $tool"
+}
+
+require_executable() {
+    local path="$1"
+    [[ -x "$path" ]] || die "required executable not found: $path"
+}
+
+json_bool() {
+    local value="$1"
+    if [[ "$value" == "true" ]]; then
+        printf 'true'
+    else
+        printf 'false'
+    fi
+}
+
+resolve_path() {
+    local path="$1"
+    (cd "$path" && pwd -P)
+}
+
+resolve_file_path() {
+    local path="$1"
+    local dir
+    dir="$(dirname -- "$path")"
+    printf '%s/%s\n' "$(resolve_path "$dir")" "$(basename -- "$path")"
+}
+
+format_ratio() {
+    local numerator="$1"
+    local denominator="$2"
+    awk -v numerator="$numerator" -v denominator="$denominator" 'BEGIN {
+        if (denominator == 0) {
+            printf "n/a"
+        } else {
+            printf "%.4f", numerator / denominator
+        }
+    }'
+}
+
+format_mib() {
+    local bytes="$1"
+    awk -v bytes="$bytes" 'BEGIN { printf "%.2f", bytes / 1048576 }'
+}
+
+json_array_from_args() {
+    if (($# == 0)); then
+        printf '[]'
+    else
+        printf '%s\0' "$@" | jq -Rs 'split("\u0000")[:-1]'
+    fi
+}
+
+print_command() {
+    local part
+    for part in "$@"; do
+        printf '%q ' "$part"
+    done
+    printf '\n'
+}
+
+load_env_file() {
+    local env_file="$1"
+    [[ -f "$env_file" ]] || return 0
+    # shellcheck disable=SC1090
+    . "$env_file"
+}
+
+profile_case_root() {
+    local profile_spec="$1"
+    printf '%s\n' "${profile_spec%%/*}"
+}
+
+resolve_profile_file() {
+    local geodepot_bin="$1"
+    local profile_spec="$2"
+    local profile_case_root_value
+    local candidate_path
+    local resolved_path
+
+    profile_case_root_value="$(profile_case_root "$profile_spec")"
+    for candidate_path in \
+        "$profile_case_root_value/$PROFILE_CONFIG_BASENAME" \
+        "$profile_case_root_value/$PROFILE_CONFIG_TYPO_BASENAME"
+    do
+        if resolved_path="$("$geodepot_bin" get "$candidate_path" 2>/dev/null)"; then
+            [[ -n "$resolved_path" ]] || continue
+            printf '%s\n' "$resolved_path"
+            return 0
+        fi
+    done
+
+    printf 'error: could not resolve profile config for %s (looked for %s and %s)\n' \
+        "$profile_spec" \
+        "$PROFILE_CONFIG_BASENAME" \
+        "$PROFILE_CONFIG_TYPO_BASENAME" >&2
+    return 1
+}
+
+input_root=""
+profile_spec=""
+profile_input_root=""
+run_label=""
+output_root="$DEFAULT_OUTPUT_ROOT"
+
+while (($#)); do
+    case "$1" in
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        --profile)
+            [[ $# -ge 2 ]] || die "--profile requires a value"
+            profile_spec="$2"
+            shift 2
+            ;;
+        --input)
+            [[ $# -ge 2 ]] || die "--input requires a path"
+            input_root="$2"
+            shift 2
+            ;;
+        --label)
+            [[ $# -ge 2 ]] || die "--label requires a value"
+            run_label="$2"
+            shift 2
+            ;;
+        --output-root)
+            [[ $# -ge 2 ]] || die "--output-root requires a path"
+            output_root="$2"
+            shift 2
+            ;;
+        --)
+            shift
+            continue
+            ;;
+        *)
+            die "unknown argument: $1"
+            ;;
+    esac
+done
+
+if (($#)); then
+    die "unexpected positional arguments: $*"
+fi
+
+if [[ -n "$profile_spec" && -n "$input_root" ]]; then
+    die "--profile cannot be combined with --input"
+fi
+
+if [[ -n "$profile_spec" && -n "$run_label" ]]; then
+    die "--profile cannot be combined with --label"
+fi
+
+require_tool cargo
+require_tool git
+require_tool jq
+require_tool perf
+require_tool valgrind
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+repo_root="$(cd "$script_dir/.." && pwd -P)"
+
+if [[ -z "${GEODEPOT_BIN:-}" ]]; then
+    load_env_file "$repo_root/$DEFAULT_GEODEPOT_ENV_FILE"
+fi
+
+geodepot_bin="${GEODEPOT_BIN:-}"
+
+if [[ -n "$profile_spec" ]]; then
+    [[ -n "$geodepot_bin" ]] || die "GEODEPOT_BIN is required when using --profile; set it in $DEFAULT_GEODEPOT_ENV_FILE"
+    require_executable "$geodepot_bin"
+
+    profile_input_root="$("$geodepot_bin" get "$profile_spec" 2>/dev/null)" || die "could not resolve input root for profile: $profile_spec"
+    [[ -n "$profile_input_root" ]] || die "could not resolve input root for profile: $profile_spec"
+
+    if ! profile_file="$(resolve_profile_file "$geodepot_bin" "$profile_spec")"; then
+        exit 1
+    fi
+
+    if [[ -z "$input_root" ]]; then
+        input_root="$profile_input_root"
+    fi
+fi
+
+[[ -n "$input_root" ]] || die "either --profile or --input is required"
+
+if [[ "$input_root" != /* ]]; then
+    input_root="$PWD/$input_root"
+fi
+input_root="$(resolve_path "$input_root")"
+
+if [[ "$output_root" != /* ]]; then
+    output_root="$repo_root/$output_root"
+fi
+mkdir -p "$output_root"
+output_root="$(resolve_path "$output_root")"
+
+[[ -d "$input_root" ]] || die "input dataset root does not exist: $input_root"
+
+profile_tyler_args_json='[]'
+profile_env_json='{}'
+profile_tyler_args=()
+if [[ -n "${profile_file:-}" ]]; then
+    [[ -f "$profile_file" ]] || die "profile config file does not exist: $profile_file"
+    profile_tyler_args_json="$(
+        jq -c '
+            if type == "array" then .
+            elif type == "object" then (.tyler_args // .args // [])
+            else error("profile config must be a JSON array or object")
+            end
+        ' "$profile_file"
+    )"
+    profile_env_json="$(
+        jq -c '
+            if type == "object" then (.env // {})
+            else {}
+            end
+        ' "$profile_file"
+    )"
+    mapfile -t profile_tyler_args < <(
+        jq -r '
+            .[]
+            | tostring
+        ' <<< "$profile_tyler_args_json"
+    )
+    while IFS=$'\t' read -r key value; do
+        [[ -n "$key" ]] || continue
+        export "$key=$value"
+    done < <(
+        jq -r '
+            to_entries[]
+            | [.key, (.value | tostring)]
+            | @tsv
+        ' <<< "$profile_env_json"
+    )
+fi
+
+git_sha="$(git -C "$repo_root" rev-parse HEAD)"
+git_short_sha="$(git -C "$repo_root" rev-parse --short HEAD)"
+git_branch="$(git -C "$repo_root" rev-parse --abbrev-ref HEAD)"
+git_describe="$(git -C "$repo_root" describe --tags --always --dirty 2>/dev/null || true)"
+git_dirty="false"
+if [[ -n "$(git -C "$repo_root" status --porcelain=v1)" ]]; then
+    git_dirty="true"
+fi
+
+hostname_value="$(hostname)"
+uname_value="$(uname -srvmo)"
+rustc_version="$(rustc --version)"
+cargo_version="$(cargo --version)"
+perf_version="$(perf --version)"
+valgrind_version="$(valgrind --version)"
+created_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+timestamp="$(date -u +%Y-%m-%dT%H-%M-%S-%NZ)"
+run_id="${timestamp}__pid$$"
+if [[ -n "$profile_spec" ]]; then
+    run_id+="__$(sanitize_label "$profile_spec")"
+fi
+if [[ -n "$run_label" ]]; then
+    run_id+="__$(sanitize_label "$run_label")"
+fi
+
+final_run_dir="$output_root/$run_id"
+[[ ! -e "$final_run_dir" ]] || die "run directory already exists: $final_run_dir"
+
+staging_dir="$(mktemp -d "$output_root/.tyler-profile-staging.XXXXXX")"
+finalized="false"
+cleanup() {
+    if [[ "$finalized" != "true" && -d "$staging_dir" ]]; then
+        rm -rf "$staging_dir"
+    fi
+}
+trap cleanup EXIT
+
+binary_path="$repo_root/target/release/tyler"
+build_command=(cargo build --release --locked --bin tyler --manifest-path "$repo_root/Cargo.toml")
+tyler_output_base="$staging_dir/outputs"
+mkdir -p "$tyler_output_base"
+
+printf 'Building profiling binary...\n'
+(
+    cd "$repo_root"
+    RUSTFLAGS="$RUSTFLAGS_VALUE" "${build_command[@]}"
+)
+
+[[ -x "$binary_path" ]] || die "expected profiling binary not found: $binary_path"
+
+perf_output_dir="$tyler_output_base/perf"
+massif_output_dir="$tyler_output_base/massif"
+mkdir -p "$perf_output_dir" "$massif_output_dir"
+
+perf_raw_json="$staging_dir/perf-stat.raw.json"
+perf_stderr="$staging_dir/perf-stat.stderr.log"
+tyler_perf_command=("$binary_path" "$input_root")
+tyler_perf_command+=( "${profile_tyler_args[@]}" )
+tyler_perf_command+=( --output "$perf_output_dir" )
+perf_command=(perf stat -j -e "$PERF_EVENTS" -o "$perf_raw_json" -- "${tyler_perf_command[@]}")
+
+printf 'Running perf stat...\n'
+printf 'Tyler command: ' >&2
+print_command "${tyler_perf_command[@]}" >&2
+perf_start_ns="$(date +%s%N)"
+set +e
+"${perf_command[@]}" > /dev/null 2> "$perf_stderr"
+perf_status="$?"
+set -e
+perf_end_ns="$(date +%s%N)"
+perf_elapsed_seconds="$(awk -v start="$perf_start_ns" -v end="$perf_end_ns" 'BEGIN { printf "%.6f", (end - start) / 1000000000 }')"
+if [[ "$perf_status" -ne 0 ]]; then
+    die "perf run failed with exit status $perf_status; see $perf_stderr"
+fi
+
+perf_summary_json="$staging_dir/perf-stat.json"
+jq -s \
+    --arg wall_clock_seconds "$perf_elapsed_seconds" \
+    '
+    def event_value($name):
+        ([.[] | select(.event == $name)] | first)."counter-value" | tonumber;
+    def ratio($numerator; $denominator):
+        if $denominator == 0 then null else ($numerator / $denominator) end;
+    {
+        wall_clock_seconds: ($wall_clock_seconds | tonumber),
+        counters: {
+            cycles: event_value("cycles"),
+            instructions: event_value("instructions"),
+            instructions_per_cycle: ratio(event_value("instructions"); event_value("cycles")),
+            cache_references: event_value("cache-references"),
+            cache_misses: event_value("cache-misses"),
+            cache_miss_rate: ratio(event_value("cache-misses"); event_value("cache-references")),
+            page_faults: event_value("page-faults"),
+            context_switches: event_value("context-switches"),
+            cpu_migrations: event_value("cpu-migrations"),
+            branches: event_value("branches"),
+            branch_misses: event_value("branch-misses")
+        },
+        raw_events: .
+    }
+    ' "$perf_raw_json" > "$perf_summary_json"
+
+perf_cycles="$(jq -r '.counters.cycles' "$perf_summary_json")"
+perf_instructions="$(jq -r '.counters.instructions' "$perf_summary_json")"
+perf_cache_refs="$(jq -r '.counters.cache_references' "$perf_summary_json")"
+perf_cache_misses="$(jq -r '.counters.cache_misses' "$perf_summary_json")"
+perf_page_faults="$(jq -r '.counters.page_faults' "$perf_summary_json")"
+perf_context_switches="$(jq -r '.counters.context_switches' "$perf_summary_json")"
+perf_cpu_migrations="$(jq -r '.counters.cpu_migrations' "$perf_summary_json")"
+perf_branches="$(jq -r '.counters.branches' "$perf_summary_json")"
+perf_branch_misses="$(jq -r '.counters.branch_misses' "$perf_summary_json")"
+
+massif_raw="$staging_dir/massif.out"
+massif_stdout="$staging_dir/massif.stdout.log"
+massif_stderr="$staging_dir/massif.stderr.log"
+tyler_massif_command=("$binary_path" "$input_root")
+tyler_massif_command+=( "${profile_tyler_args[@]}" )
+tyler_massif_command+=( --output "$massif_output_dir" )
+massif_command=(valgrind --tool=massif --time-unit="$MASSIF_TIME_UNIT" --massif-out-file="$massif_raw" -- "${tyler_massif_command[@]}")
+
+printf 'Running Massif...\n'
+printf 'Tyler command: ' >&2
+print_command "${tyler_massif_command[@]}" >&2
+massif_start_ns="$(date +%s%N)"
+set +e
+"${massif_command[@]}" > "$massif_stdout" 2> "$massif_stderr"
+massif_status="$?"
+set -e
+massif_end_ns="$(date +%s%N)"
+massif_elapsed_seconds="$(awk -v start="$massif_start_ns" -v end="$massif_end_ns" 'BEGIN { printf "%.6f", (end - start) / 1000000000 }')"
+if [[ "$massif_status" -ne 0 ]]; then
+    die "Massif run failed with exit status $massif_status; see $massif_stderr"
+fi
+
+read -r peak_heap_bytes peak_snapshot peak_time snapshot_count max_heap_growth_bytes max_heap_growth_from_snapshot max_heap_growth_to_snapshot max_heap_growth_time < <(
+    awk '
+        BEGIN {
+            snapshot = -1;
+            time = 0;
+            peak_heap = -1;
+            peak_snapshot = -1;
+            peak_time = 0;
+            snapshot_count = 0;
+            max_heap_growth = -1;
+            max_from = -1;
+            max_to = -1;
+            max_growth_time = 0;
+            prev_heap = -1;
+            prev_snapshot = -1;
+        }
+        /^snapshot=/ {
+            snapshot = substr($0, 10) + 0;
+            snapshot_count += 1;
+            next;
+        }
+        /^time=/ {
+            time = substr($0, 6) + 0;
+            next;
+        }
+        /^mem_heap_B=/ {
+            heap = substr($0, 12) + 0;
+            if (heap > peak_heap) {
+                peak_heap = heap;
+                peak_snapshot = snapshot;
+                peak_time = time;
+            }
+            if (prev_heap >= 0) {
+                growth = heap - prev_heap;
+                if (growth > max_heap_growth) {
+                    max_heap_growth = growth;
+                    max_from = prev_snapshot;
+                    max_to = snapshot;
+                    max_growth_time = time;
+                }
+            }
+            prev_heap = heap;
+            prev_snapshot = snapshot;
+            next;
+        }
+        END {
+            if (peak_heap < 0) {
+                peak_heap = 0;
+                peak_snapshot = 0;
+                peak_time = 0;
+            }
+            if (max_heap_growth < 0) {
+                max_heap_growth = 0;
+                max_from = 0;
+                max_to = 0;
+                max_growth_time = 0;
+            }
+            printf "%s %s %s %s %s %s %s %s\n", peak_heap, peak_snapshot, peak_time, snapshot_count, max_heap_growth, max_from, max_to, max_growth_time;
+        }
+    ' "$massif_raw"
+)
+
+massif_summary_json="$staging_dir/massif-summary.json"
+jq -n \
+    --arg time_unit "$MASSIF_TIME_UNIT" \
+    --argjson peak_heap_bytes "$peak_heap_bytes" \
+    --argjson peak_snapshot "$peak_snapshot" \
+    --argjson peak_time "$peak_time" \
+    --argjson snapshot_count "$snapshot_count" \
+    --argjson max_heap_growth_bytes "$max_heap_growth_bytes" \
+    --argjson max_heap_growth_from_snapshot "$max_heap_growth_from_snapshot" \
+    --argjson max_heap_growth_to_snapshot "$max_heap_growth_to_snapshot" \
+    --argjson max_heap_growth_time "$max_heap_growth_time" \
+    '{
+        time_unit: $time_unit,
+        peak_heap_bytes: $peak_heap_bytes,
+        peak_heap_mib: ($peak_heap_bytes / 1048576),
+        peak_snapshot: $peak_snapshot,
+        peak_time: $peak_time,
+        snapshot_count: $snapshot_count,
+        max_heap_growth_bytes: $max_heap_growth_bytes,
+        max_heap_growth_from_snapshot: $max_heap_growth_from_snapshot,
+        max_heap_growth_to_snapshot: $max_heap_growth_to_snapshot,
+        max_heap_growth_time: $max_heap_growth_time
+    }' > "$massif_summary_json"
+
+peak_heap_mib="$(format_mib "$peak_heap_bytes")"
+max_heap_growth_mib="$(format_mib "$max_heap_growth_bytes")"
+perf_cache_miss_rate_display="$(format_ratio "$perf_cache_misses" "$perf_cache_refs")"
+perf_ipc_display="$(format_ratio "$perf_instructions" "$perf_cycles")"
+
+manifest_json="$staging_dir/manifest.json"
+jq_profile_tyler_args="$(json_array_from_args "${profile_tyler_args[@]}")"
+jq_perf_command="$(json_array_from_args "${perf_command[@]}")"
+jq_massif_command="$(json_array_from_args "${massif_command[@]}")"
+jq_tyler_perf_command="$(json_array_from_args "${tyler_perf_command[@]}")"
+jq_tyler_massif_command="$(json_array_from_args "${tyler_massif_command[@]}")"
+jq -n \
+    --arg run_id "$run_id" \
+    --arg run_label "$run_label" \
+    --arg created_at "$created_at" \
+    --arg repo_root "$repo_root" \
+    --arg input_root "$input_root" \
+    --arg profile_spec "$profile_spec" \
+    --arg profile_input_root "$profile_input_root" \
+    --arg profile_file "${profile_file:-}" \
+    --argjson profile_tyler_args "$jq_profile_tyler_args" \
+    --argjson profile_env "$profile_env_json" \
+    --arg output_root "$output_root" \
+    --arg staging_dir "$staging_dir" \
+    --arg run_dir "$final_run_dir" \
+    --arg binary_path "$binary_path" \
+    --arg geodepot_bin "${geodepot_bin:-}" \
+    --arg git_sha "$git_sha" \
+    --arg git_short_sha "$git_short_sha" \
+    --arg git_branch "$git_branch" \
+    --arg git_describe "$git_describe" \
+    --argjson git_dirty "$(json_bool "$git_dirty")" \
+    --arg hostname "$hostname_value" \
+    --arg uname "$uname_value" \
+    --arg rustc_version "$rustc_version" \
+    --arg cargo_version "$cargo_version" \
+    --arg perf_version "$perf_version" \
+    --arg valgrind_version "$valgrind_version" \
+    --arg rustflags "$RUSTFLAGS_VALUE" \
+    --arg perf_elapsed_seconds "$perf_elapsed_seconds" \
+    --arg massif_elapsed_seconds "$massif_elapsed_seconds" \
+    --arg perf_raw_json "$perf_raw_json" \
+    --arg massif_raw "$massif_raw" \
+    --arg manifest_path "$repo_root/Cargo.toml" \
+    --argjson tyler_perf_command "$jq_tyler_perf_command" \
+    --argjson tyler_massif_command "$jq_tyler_massif_command" \
+    '
+    {
+        run_id: $run_id,
+        run_label: (if $run_label == "" then null else $run_label end),
+        created_at: $created_at,
+        profile: {
+            spec: (if $profile_spec == "" then null else $profile_spec end),
+            resolved_input_root: (if $profile_input_root == "" then null else $profile_input_root end),
+            profile_file: (if $profile_file == "" then null else $profile_file end),
+            tyler_args: $profile_tyler_args,
+            env: $profile_env,
+            geodepot_bin: (if $geodepot_bin == "" then null else $geodepot_bin end)
+        },
+        git: {
+            sha: $git_sha,
+            short_sha: $git_short_sha,
+            branch: $git_branch,
+            describe: $git_describe,
+            dirty: $git_dirty
+        },
+        host: {
+            hostname: $hostname,
+            uname: $uname
+        },
+        versions: {
+            rustc: $rustc_version,
+            cargo: $cargo_version,
+            perf: $perf_version,
+            valgrind: $valgrind_version
+        },
+        paths: {
+            repo_root: $repo_root,
+            input_root: $input_root,
+            output_root: $output_root,
+            staging_dir: $staging_dir,
+            run_dir: $run_dir,
+            binary_path: $binary_path,
+            manifest_path: $manifest_path
+        },
+        build: {
+            command: ["cargo", "build", "--release", "--locked", "--bin", "tyler", "--manifest-path", $manifest_path],
+            rustflags: $rustflags
+        },
+        perf: {
+            command: $jq_perf_command,
+            tyler_command: $tyler_perf_command,
+            wall_clock_seconds: ($perf_elapsed_seconds | tonumber)
+        },
+        massif: {
+            command: $jq_massif_command,
+            tyler_command: $tyler_massif_command,
+            wall_clock_seconds: ($massif_elapsed_seconds | tonumber)
+        }
+    }
+    ' > "$manifest_json"
+
+cat > "$staging_dir/summary.md" <<EOF
+# Tyler profiling run
+
+- Run ID: $run_id
+- Git SHA: $git_sha
+- Branch: $git_branch
+- Created: $created_at
+- Geodepot profile: ${profile_spec:-manual}
+- Geodepot input: ${profile_input_root:-n/a}
+- Profile config: ${profile_file:-n/a}
+- Input: $input_root
+- Output directory: $final_run_dir
+- Binary: $binary_path
+- Perf wall clock: ${perf_elapsed_seconds}s
+- Perf IPC: ${perf_ipc_display}
+- Perf cache references: $perf_cache_refs
+- Perf cache misses: $perf_cache_misses
+- Perf cache miss rate: ${perf_cache_miss_rate_display}
+- Perf page faults: $perf_page_faults
+- Perf context switches: $perf_context_switches
+- Perf CPU migrations: $perf_cpu_migrations
+- Perf branches: $perf_branches
+- Perf branch misses: $perf_branch_misses
+- Massif wall clock: ${massif_elapsed_seconds}s
+- Massif peak heap: ${peak_heap_mib} MiB (${peak_heap_bytes} bytes)
+- Massif peak snapshot: $peak_snapshot
+- Massif snapshots: $snapshot_count
+- Massif max heap growth: ${max_heap_growth_mib} MiB (${max_heap_growth_bytes} bytes)
+- Massif max heap growth snapshots: $max_heap_growth_from_snapshot -> $max_heap_growth_to_snapshot
+
+Committed artifacts are the JSON summaries and this markdown note. Raw perf and Massif dumps are staged only while the profiler runs.
+EOF
+
+rm -rf "$tyler_output_base" "$perf_raw_json" "$perf_stderr" "$massif_raw" "$massif_stdout" "$massif_stderr"
+
+mv "$staging_dir" "$final_run_dir"
+finalized="true"
+trap - EXIT
+
+printf 'Wrote profiling run to %s\n' "$final_run_dir"

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,6 +69,7 @@ use std::fs;
 use std::fs::File;
 use std::io::Write;
 use std::path::{Path, PathBuf};
+use std::time::Instant;
 
 use crate::coordinates::RootEnuFrame;
 use crate::formats::cesium3dtiles::{Tile, TileId};
@@ -565,6 +566,7 @@ fn read_tile_feature_models(
     world: &parser::World,
     feature_ids: &[usize],
 ) -> Result<Vec<cityjson_lib::CityModel>, Box<dyn std::error::Error>> {
+    let started = Instant::now();
     let mut models = Vec::with_capacity(feature_ids.len());
     let mut cjindex_refs = Vec::with_capacity(feature_ids.len());
     for fid in feature_ids {
@@ -590,6 +592,11 @@ fn read_tile_feature_models(
         }
     }
     models = parser::World::read_cjindex_features_thread_local(&world.input_source, &cjindex_refs)?;
+    debug!(
+        "Read {} tile features from cjindex in {:?}",
+        models.len(),
+        started.elapsed()
+    );
 
     Ok(models)
 }
@@ -610,8 +617,14 @@ fn build_tile_model_from_feature_ids(
     if models.is_empty() {
         return Err("tile model preparation removed all CityObjects".into());
     }
+    let merge_started = Instant::now();
     let merged = cityjson_lib::ops::merge(models)?;
-    cleanup_and_update_extents(merged)
+    debug!(
+        "Merged tile model for {} selected features in {:?}",
+        feature_ids.len(),
+        merge_started.elapsed()
+    );
+    Ok(merged)
 }
 
 #[cfg(test)]
@@ -654,12 +667,19 @@ fn prepare_tile_feature_models(
     include_parent_attributes: bool,
     cleanup_features: bool,
 ) -> Result<Vec<cityjson_lib::CityModel>, Box<dyn std::error::Error>> {
-    read_tile_feature_models(world, feature_ids)?
+    let models = read_tile_feature_models(world, feature_ids)?;
+    models
         .into_iter()
-        .filter_map(|model| {
+        .zip(feature_ids.iter().copied())
+        .filter_map(|(model, feature_id)| {
             match prepare_feature_model(
                 model,
-                world,
+                feature_id,
+                world.cityobject_types.as_ref(),
+                world
+                    .cityobject_types
+                    .as_ref()
+                    .is_some_and(|_| world.features[feature_id].needs_type_filter),
                 feature_type_lods,
                 include_parent_attributes,
                 cleanup_features,
@@ -674,24 +694,61 @@ fn prepare_tile_feature_models(
 
 fn prepare_feature_model(
     model: cityjson_lib::CityModel,
-    world: &parser::World,
+    feature_id: usize,
+    cityobject_types: Option<&Vec<parser::CityObjectType>>,
+    needs_type_filter: bool,
     feature_type_lods: &BTreeMap<String, String>,
     include_parent_attributes: bool,
     cleanup_feature: bool,
 ) -> Result<Option<cityjson_lib::CityModel>, Box<dyn std::error::Error>> {
     let mut model = model;
+    let prepare_started = Instant::now();
+    let lods_pruned = !feature_type_lods.is_empty();
     prune_lod_geometries(&mut model, feature_type_lods)?;
     if include_parent_attributes {
         inherit_parent_attributes(&mut model)?;
     }
-    let model = filter_cityobject_types(model, world.cityobject_types.as_ref())?;
-    let model = remove_empty_geometry_cityobjects(&model)?;
+    let type_filter_started = Instant::now();
+    let model = if needs_type_filter {
+        filter_cityobject_types(model, cityobject_types)?
+    } else {
+        model
+    };
+    if needs_type_filter {
+        debug!(
+            "Filtered feature {} cityobject types in {:?}",
+            feature_id,
+            type_filter_started.elapsed()
+        );
+    }
+    let remove_empty_geometry =
+        cleanup_feature || lods_pruned || include_parent_attributes || needs_type_filter;
+    let model = if remove_empty_geometry {
+        remove_empty_geometry_cityobjects(&model)?
+    } else {
+        model
+    };
     if model.cityobjects().is_empty() {
         return Ok(None);
     }
     if cleanup_feature {
-        cleanup_and_update_extents(model).map(Some)
+        let cleanup_started = Instant::now();
+        let cleaned = cleanup_and_update_extents(model)?;
+        debug!(
+            "Cleaned debug tile feature {} in {:?} (total prepare {:?})",
+            feature_id,
+            cleanup_started.elapsed(),
+            prepare_started.elapsed()
+        );
+        Ok(Some(cleaned))
     } else {
+        debug!(
+            "Prepared tile feature {} in {:?} (type_filter={}, remove_empty={}, cleanup=false)",
+            feature_id,
+            prepare_started.elapsed(),
+            needs_type_filter,
+            remove_empty_geometry
+        );
         Ok(Some(model))
     }
 }
@@ -1298,6 +1355,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     return Some(job);
                 }
             }
+            debug!(
+                "Prepared merged CityJSON model for tile {} with {} CityObjects and {} vertices",
+                job.content_tile_id,
+                model.cityobjects().len(),
+                model.vertices().len()
+            );
             let mut tile_export_options = export_options.clone();
             if cli.cesium3dtiles_content_clip_to_tile_bounds {
                 if cli.cesium3dtiles_implicit {
@@ -1319,12 +1382,18 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     tile_export_options.clip_bbox = Some(qtree_node.bbox(&world.grid));
                 }
             }
+            let convert_started = Instant::now();
             if let Err(error) =
                 cityjson_convert::convert_to_glb(&model, &output_file, &tile_export_options)
             {
                 warn!("Tile {} conversion failed: {}", job.content_tile_id, error);
                 return Some(job);
             }
+            debug!(
+                "Converted tile {} to GLB in {:?}",
+                job.content_tile_id,
+                convert_started.elapsed()
+            );
             if !output_file.exists() {
                 warn!(
                     "Tile {} conversion failed: {} was not created",
@@ -1550,6 +1619,25 @@ mod tests {
         serde_json::from_slice(&feature_output).expect("feature json should parse")
     }
 
+    fn geometry_relevant_signature(model: &cityjson_lib::CityModel) -> (usize, usize, Vec<String>) {
+        let mut cityobject_types = model
+            .cityobjects()
+            .iter()
+            .filter(|(_, cityobject)| {
+                cityobject
+                    .geometry()
+                    .is_some_and(|geometries| !geometries.is_empty())
+            })
+            .map(|(_, cityobject)| cityobject.type_cityobject().to_string())
+            .collect::<Vec<_>>();
+        cityobject_types.sort();
+        (
+            model.vertices().len(),
+            model.geometry_count(),
+            cityobject_types,
+        )
+    }
+
     fn feature_attribute_string(feature: &Value, object_id: &str, key: &str) -> Option<String> {
         feature
             .get("CityObjects")?
@@ -1579,6 +1667,82 @@ mod tests {
         let model =
             remove_empty_geometry_cityobjects(&model).expect("empty object removal should succeed");
         cleanup_and_update_extents(model).expect("cleanup should succeed")
+    }
+
+    #[test]
+    fn prepare_feature_model_skips_empty_geometry_removal_for_gltf_noop_path() {
+        let model = parent_attribute_remapping_fixture(serde_json::json!({}));
+        let original_signature = geometry_relevant_signature(&model);
+
+        let prepared = prepare_feature_model(
+            model.clone(),
+            0,
+            None,
+            false,
+            &BTreeMap::new(),
+            false,
+            false,
+        )
+        .expect("feature preparation should succeed")
+        .expect("feature should remain");
+
+        assert_eq!(geometry_relevant_signature(&prepared), original_signature);
+        assert_eq!(
+            prepared.cityobjects().len(),
+            model.cityobjects().len(),
+            "no-op glTF preparation should not rebuild the feature by removing empty parents"
+        );
+    }
+
+    #[test]
+    fn prepare_feature_model_type_filter_skip_matches_filtered_geometry() {
+        let model = cityjson_lib::json::from_feature_slice(
+            br#"{
+                "type":"CityJSONFeature",
+                "id":"building-part",
+                "CityObjects":{
+                    "building-part":{
+                        "type":"BuildingPart",
+                        "geometry":[{
+                            "type":"MultiSurface",
+                            "lod":"1",
+                            "boundaries":[[[0,1,2]]]
+                        }]
+                    }
+                },
+                "vertices":[[0,0,0],[1,0,0],[0,1,0]]
+            }"#,
+        )
+        .expect("building-part fixture should parse");
+        let selected_types = vec![parser::CityObjectType::BuildingPart];
+
+        let skipped = prepare_feature_model(
+            model.clone(),
+            0,
+            Some(&selected_types),
+            false,
+            &BTreeMap::new(),
+            false,
+            false,
+        )
+        .expect("skipped filter preparation should succeed")
+        .expect("skipped filter feature should remain");
+        let filtered = prepare_feature_model(
+            model,
+            0,
+            Some(&selected_types),
+            true,
+            &BTreeMap::new(),
+            false,
+            false,
+        )
+        .expect("filtered preparation should succeed")
+        .expect("filtered feature should remain");
+
+        assert_eq!(
+            geometry_relevant_signature(&skipped),
+            geometry_relevant_signature(&filtered)
+        );
     }
 
     #[test]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -18,6 +18,7 @@ use std::collections::BTreeMap;
 use std::fmt;
 use std::fs::File;
 use std::path::{Path, PathBuf};
+use std::time::Instant;
 
 use cityjson::v2_0::vertex::VertexIndex as GeometryVertexIndex;
 use cityjson_index::{CityIndex, StorageLayout};
@@ -288,8 +289,15 @@ impl World {
 
         self.features.clear();
         let city_index = self.input_source.open_index()?;
+        let mut page_count = 0usize;
+        let mut scanned_features = 0usize;
+        let mut indexed_features = 0usize;
+        let started = Instant::now();
         for page_result in city_index.scan_feature_pages(CJINDEX_PAGE_SIZE)? {
+            let page_started = Instant::now();
             let page = page_result?;
+            page_count += 1;
+            scanned_features += page.len();
             let feature_in_cells = page
                 .into_par_iter()
                 .map(|feature| -> Option<FeatureInGridCells> {
@@ -300,10 +308,23 @@ impl World {
                 })
                 .collect::<Vec<_>>();
             for feature_in_cells in feature_in_cells.into_iter().flatten() {
+                indexed_features += 1;
                 self.integrate_feature_in_cells(feature_in_cells);
             }
+            debug!(
+                "Indexed cjindex feature page {page_count} in {:?} ({} scanned, {} retained so far)",
+                page_started.elapsed(),
+                scanned_features,
+                indexed_features
+            );
         }
-        debug!("indexed {} features", self.features.len());
+        info!(
+            "Indexed {} of {} scanned features into grid cells across {} pages in {:?}",
+            self.features.len(),
+            scanned_features,
+            page_count,
+            started.elapsed()
+        );
         Ok(())
     }
 
@@ -312,23 +333,52 @@ impl World {
         feature_reference: FeatureReference,
         model: &cityjson_lib::CityModel,
     ) -> Option<FeatureInGridCells> {
+        let stats_started = Instant::now();
         let stats = selected_geometry_stats(model, self.cityobject_types.as_ref());
+        debug!(
+            "selected_geometry_stats collected {} vertices for {:?} in {:?}",
+            stats.selected_vertices.len(),
+            feature_reference,
+            stats_started.elapsed()
+        );
         let bbox = stats.bbox?;
         let centroid = stats.centroid?;
+
+        let uses_unique_assignment =
+            selected_types_use_unique_assignment(&stats.selected_object_types);
+        let feature = Feature {
+            centroid,
+            reference: feature_reference,
+            bbox,
+            needs_type_filter: !stats.ignored_object_types.is_empty(),
+        };
+
+        if uses_unique_assignment {
+            let count_started = Instant::now();
+            let (cellid, nr_vertices) =
+                count_unique_assignment_cell(model, &stats.selected_vertices, &self.grid, &bbox)?;
+            debug!(
+                "Selected unique assignment grid cell {:?} with {} vertices in {:?}",
+                cellid,
+                nr_vertices,
+                count_started.elapsed()
+            );
+            return Some(Self::feature_to_unique_cell(feature, cellid, nr_vertices));
+        }
+
+        let count_started = Instant::now();
         let cell_vtx_cnt =
             count_vertices_in_grid(model, &stats.selected_vertices, &self.grid, &bbox);
+        debug!(
+            "Counted {} grid cells for {:?} in {:?}",
+            cell_vtx_cnt.len(),
+            feature.reference,
+            count_started.elapsed()
+        );
         if cell_vtx_cnt.is_empty() {
             return None;
         }
-        Self::feature_to_cells(
-            Feature {
-                centroid,
-                reference: feature_reference,
-                bbox,
-            },
-            cell_vtx_cnt,
-            &stats.selected_object_types,
-        )
+        Self::feature_to_cells(feature, cell_vtx_cnt)
     }
 
     fn integrate_feature_in_cells(&mut self, feature_in_cells: FeatureInGridCells) {
@@ -343,32 +393,10 @@ impl World {
         }
     }
 
-    fn feature_to_cells(
-        feature: Feature,
-        cell_vtx_cnt: CellCounts,
-        selected_object_types: &[CityObjectType],
-    ) -> Option<FeatureInGridCells> {
-        let unique_assignment = selected_object_types.iter().any(|cotype| {
-            // In this case we have a 1-1 feature-to-cell assignment, we only retain the vertex
-            // count in the cell that gets the feature.
-            // The cell that receives the feature is the one with the highest vertex count
-            // of the feature.
-            // However, with this method it is not possible to combine cityobject types that
-            // require different cell-assignment methods into the same tileset.
-            // E.g. terrain features need to be duplicated across cells, buildings need to
-            // unique. The tileset for them must be generated separately.
-            matches!(
-                cotype,
-                CityObjectType::Building | CityObjectType::BuildingPart
-            )
-        });
+    fn feature_to_cells(feature: Feature, cell_vtx_cnt: CellCounts) -> Option<FeatureInGridCells> {
         let mut cells: Vec<(CellId, Cell)> = Vec::with_capacity(cell_vtx_cnt.len());
 
-        if unique_assignment {
-            let (cellid, nr_vertices) = cell_vtx_cnt
-                .iter()
-                .max_by(|a, b| a.1.cmp(b.1))
-                .expect("non-empty cell counts should have a maximum");
+        for (cellid, nr_vertices) in cell_vtx_cnt.iter() {
             cells.push((
                 *cellid,
                 Cell {
@@ -376,18 +404,25 @@ impl World {
                     nr_vertices: *nr_vertices,
                 },
             ));
-        } else {
-            for (cellid, nr_vertices) in cell_vtx_cnt.iter() {
-                cells.push((
-                    *cellid,
-                    Cell {
-                        feature_ids: Vec::new(),
-                        nr_vertices: *nr_vertices,
-                    },
-                ));
-            }
         }
         Some(FeatureInGridCells { feature, cells })
+    }
+
+    fn feature_to_unique_cell(
+        feature: Feature,
+        cellid: CellId,
+        nr_vertices: usize,
+    ) -> FeatureInGridCells {
+        FeatureInGridCells {
+            feature,
+            cells: vec![(
+                cellid,
+                Cell {
+                    feature_ids: Vec::new(),
+                    nr_vertices,
+                },
+            )],
+        }
     }
 
     pub fn export_grid(
@@ -460,12 +495,18 @@ pub struct Feature {
     pub(crate) centroid: [f64; 2],
     pub reference: FeatureReference,
     pub bbox: Bbox,
+    #[serde(default = "default_feature_needs_type_filter")]
+    pub needs_type_filter: bool,
 }
 
 impl Feature {
     pub fn centroid(&self) -> [f64; 2] {
         self.centroid
     }
+}
+
+fn default_feature_needs_type_filter() -> bool {
+    true
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -532,8 +573,9 @@ fn selected_geometry_stats(
     model: &cityjson::v2_0::OwnedCityModel,
     filter: Option<&Vec<CityObjectType>>,
 ) -> SelectedGeometryStats {
-    let mut selected_vertices = Vec::new();
-    let mut geometry_scratch = Vec::new();
+    let vertex_scratch_capacity = model.vertices().len().min(4096);
+    let mut selected_vertices = Vec::with_capacity(vertex_scratch_capacity);
+    let mut geometry_scratch = Vec::with_capacity(vertex_scratch_capacity);
     let mut bbox: Option<Bbox> = None;
     let mut x_sum = 0.0;
     let mut y_sum = 0.0;
@@ -569,6 +611,18 @@ fn selected_geometry_stats(
         selected_object_types,
         ignored_object_types,
     }
+}
+
+fn selected_types_use_unique_assignment(selected_object_types: &[CityObjectType]) -> bool {
+    selected_object_types.iter().any(|cotype| {
+        // Building-like features are assigned once, to the cell with the
+        // highest feature score. Terrain and similar surface features keep
+        // their bbox-spanning duplicate assignment.
+        matches!(
+            cotype,
+            CityObjectType::Building | CityObjectType::BuildingPart
+        )
+    })
 }
 
 fn collect_selected_vertex_indices(
@@ -631,6 +685,74 @@ fn count_vertices_in_grid(
     }
 
     CellCounts::merge_vertex_counts_with_bbox(vertex_counts.into_iter().collect(), grid, bbox)
+}
+
+fn count_unique_assignment_cell(
+    model: &cityjson::v2_0::OwnedCityModel,
+    selected_vertices: &[GeometryVertexIndex<u32>],
+    grid: &crate::spatial_structs::SquareGrid,
+    bbox: &Bbox,
+) -> Option<(CellId, usize)> {
+    if selected_vertices.is_empty() {
+        return None;
+    }
+
+    let vertex_counts = if selected_vertices.len() >= LARGE_FEATURE_VERTEX_COUNT_THRESHOLD {
+        count_vertex_cells_parallel(model, selected_vertices, grid)
+    } else {
+        count_vertex_cells(model, selected_vertices, grid)
+    };
+
+    if vertex_counts.is_empty() {
+        return None;
+    }
+
+    max_merged_vertex_count_with_bbox(vertex_counts, grid, bbox)
+}
+
+fn max_merged_vertex_count_with_bbox(
+    vertex_counts: BTreeMap<CellId, usize>,
+    grid: &crate::spatial_structs::SquareGrid,
+    bbox: &Bbox,
+) -> Option<(CellId, usize)> {
+    let (columns, rows) = grid.intersect_bbox_ranges(bbox);
+    let min_column = *columns.start();
+    let max_column = *columns.end();
+    let min_row = *rows.start();
+    let max_row = *rows.end();
+    let mut vertex_counts = vertex_counts.into_iter().peekable();
+    let mut best: Option<(CellId, usize)> = None;
+
+    for row in min_row..=max_row {
+        for column in min_column..=max_column {
+            let bbox_cellid = CellId { row, column };
+            while let Some((cellid, count)) =
+                vertex_counts.next_if(|(cellid, _)| *cellid < bbox_cellid)
+            {
+                update_best_cell(&mut best, cellid, count);
+            }
+
+            if let Some((_, count)) = vertex_counts.next_if(|(cellid, _)| *cellid == bbox_cellid) {
+                update_best_cell(&mut best, bbox_cellid, count + 1);
+            } else {
+                update_best_cell(&mut best, bbox_cellid, 2);
+            }
+        }
+    }
+
+    for (cellid, count) in vertex_counts {
+        update_best_cell(&mut best, cellid, count);
+    }
+
+    best
+}
+
+fn update_best_cell(best: &mut Option<(CellId, usize)>, cellid: CellId, count: usize) {
+    if best.as_ref().is_none_or(|(best_cellid, best_count)| {
+        count > *best_count || (count == *best_count && cellid > *best_cellid)
+    }) {
+        *best = Some((cellid, count));
+    }
 }
 
 fn count_vertex_cells(
@@ -888,6 +1010,196 @@ mod tests {
         let bbox = stats.bbox.unwrap();
         assert!(bbox[0] > 0.0);
         assert!(bbox[1] > 0.0);
+    }
+
+    fn parse_feature(feature: serde_json::Value) -> cityjson::v2_0::OwnedCityModel {
+        cityjson_lib::json::from_feature_slice(&serde_json::to_vec(&feature).unwrap()).unwrap()
+    }
+
+    fn unique_assignment_winner_from_full_counts(counts: &CellCounts) -> Option<(CellId, usize)> {
+        counts
+            .iter()
+            .max_by(|left, right| left.1.cmp(right.1))
+            .map(|(cellid, count)| (*cellid, *count))
+    }
+
+    fn assert_unique_assignment_matches_full_counts(
+        model: &cityjson::v2_0::OwnedCityModel,
+        object_type: CityObjectType,
+        grid: &crate::spatial_structs::SquareGrid,
+    ) -> (CellId, usize) {
+        let stats = selected_geometry_stats(model, Some(&vec![object_type]));
+        let bbox = stats.bbox.unwrap();
+        let full_counts = count_vertices_in_grid(model, &stats.selected_vertices, grid, &bbox);
+        let expected = unique_assignment_winner_from_full_counts(&full_counts);
+        let optimized = count_unique_assignment_cell(model, &stats.selected_vertices, grid, &bbox);
+
+        assert_eq!(optimized, expected);
+        optimized.expect("unique assignment should produce a winning cell")
+    }
+
+    #[test]
+    fn unique_assignment_single_cell_matches_full_cell_counts() {
+        let model = parse_feature(serde_json::json!({
+            "type": "CityJSONFeature",
+            "id": "building-1",
+            "CityObjects": {
+                "building-1": {
+                    "type": "Building",
+                    "geometry": [{
+                        "type": "MultiSurface",
+                        "lod": "1.0",
+                        "boundaries": [[[0, 1, 2]]]
+                    }]
+                }
+            },
+            "vertices": [[0, 0, 0], [1, 0, 0], [0, 1, 0]]
+        }));
+        let grid = crate::spatial_structs::SquareGrid::new(
+            &[0.0, 0.0, 0.0, 100.0, 100.0, 10.0],
+            100,
+            7415,
+        );
+
+        let (cellid, count) =
+            assert_unique_assignment_matches_full_counts(&model, CityObjectType::Building, &grid);
+
+        assert_eq!(cellid, grid.locate_point(&[0.0, 0.0]));
+        assert_eq!(count, 5);
+    }
+
+    #[test]
+    fn unique_assignment_multi_cell_counts_match_full_cell_counts() {
+        let model = parse_feature(serde_json::json!({
+            "type": "CityJSONFeature",
+            "id": "building-1",
+            "CityObjects": {
+                "building-1": {
+                    "type": "Building",
+                    "geometry": [{
+                        "type": "MultiSurface",
+                        "lod": "1.0",
+                        "boundaries": [[[0, 1, 2, 3, 4]]]
+                    }]
+                }
+            },
+            "vertices": [
+                [0, 0, 0],
+                [1, 0, 0],
+                [2, 0, 0],
+                [150, 0, 0],
+                [250, 0, 0]
+            ]
+        }));
+        let grid = crate::spatial_structs::SquareGrid::new(
+            &[0.0, 0.0, 0.0, 300.0, 100.0, 10.0],
+            100,
+            7415,
+        );
+
+        let (cellid, count) =
+            assert_unique_assignment_matches_full_counts(&model, CityObjectType::Building, &grid);
+
+        assert_eq!(cellid, grid.locate_point(&[0.0, 0.0]));
+        assert_eq!(count, 5);
+    }
+
+    #[test]
+    fn unique_assignment_equal_count_tie_matches_full_cell_counts() {
+        let model = parse_feature(serde_json::json!({
+            "type": "CityJSONFeature",
+            "id": "building-1",
+            "CityObjects": {
+                "building-1": {
+                    "type": "Building",
+                    "geometry": [{
+                        "type": "MultiSurface",
+                        "lod": "1.0",
+                        "boundaries": [[[0, 1, 2, 3]]]
+                    }]
+                }
+            },
+            "vertices": [
+                [0, 0, 0],
+                [1, 0, 0],
+                [150, 0, 0],
+                [151, 0, 0]
+            ]
+        }));
+        let grid = crate::spatial_structs::SquareGrid::new(
+            &[0.0, 0.0, 0.0, 200.0, 100.0, 10.0],
+            100,
+            7415,
+        );
+
+        let (cellid, count) =
+            assert_unique_assignment_matches_full_counts(&model, CityObjectType::Building, &grid);
+
+        assert_eq!(cellid, grid.locate_point(&[150.0, 0.0]));
+        assert_eq!(count, 4);
+    }
+
+    #[test]
+    fn unique_assignment_large_bbox_keeps_bbox_only_cells_lower_scored() {
+        let model = parse_feature(serde_json::json!({
+            "type": "CityJSONFeature",
+            "id": "building-1",
+            "CityObjects": {
+                "building-1": {
+                    "type": "Building",
+                    "geometry": [{
+                        "type": "MultiSurface",
+                        "lod": "1.0",
+                        "boundaries": [[[0, 1, 2]]]
+                    }]
+                }
+            },
+            "vertices": [[0, 0, 0], [250, 250, 0], [0, 250, 0]]
+        }));
+        let grid = crate::spatial_structs::SquareGrid::new(
+            &[0.0, 0.0, 0.0, 300.0, 300.0, 10.0],
+            100,
+            7415,
+        );
+
+        let (cellid, count) =
+            assert_unique_assignment_matches_full_counts(&model, CityObjectType::Building, &grid);
+
+        assert_eq!(cellid, grid.locate_point(&[250.0, 250.0]));
+        assert_eq!(count, 3);
+    }
+
+    #[test]
+    fn unique_assignment_building_part_matches_full_cell_counts() {
+        let model = parse_feature(serde_json::json!({
+            "type": "CityJSONFeature",
+            "id": "building-part-1",
+            "CityObjects": {
+                "building-part-1": {
+                    "type": "BuildingPart",
+                    "geometry": [{
+                        "type": "MultiSurface",
+                        "lod": "1.0",
+                        "boundaries": [[[0, 1, 2]]]
+                    }]
+                }
+            },
+            "vertices": [[0, 0, 0], [1, 0, 0], [0, 1, 0]]
+        }));
+        let grid = crate::spatial_structs::SquareGrid::new(
+            &[0.0, 0.0, 0.0, 100.0, 100.0, 10.0],
+            100,
+            7415,
+        );
+
+        let (cellid, count) = assert_unique_assignment_matches_full_counts(
+            &model,
+            CityObjectType::BuildingPart,
+            &grid,
+        );
+
+        assert_eq!(cellid, grid.locate_point(&[0.0, 0.0]));
+        assert_eq!(count, 5);
     }
 
     #[test]

--- a/src/spatial_structs.rs
+++ b/src/spatial_structs.rs
@@ -1011,6 +1011,7 @@ mod tests {
                         centroid: [0.0, 0.0],
                         reference: Default::default(),
                         bbox: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                        needs_type_filter: false,
                     });
                     let xc: f64 = format!("{}.{}", &x, &f).parse().unwrap();
                     grid.insert(&[xc, y as f64], f as usize);
@@ -1031,6 +1032,7 @@ mod tests {
                         centroid: [0.0, 0.0],
                         reference: Default::default(),
                         bbox: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                        needs_type_filter: false,
                     });
                     let xc: f64 = format!("{}.{}", &x, &f).parse().unwrap();
                     grid.insert(&[xc, y as f64], f as usize);
@@ -1055,6 +1057,7 @@ mod tests {
                         centroid: [0.0, 0.0],
                         reference: Default::default(),
                         bbox: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                        needs_type_filter: false,
                     });
                     let xc: f64 = format!("{}.{}", &x, &f).parse().unwrap();
                     grid.insert(&[xc, y as f64], f as usize);


### PR DESCRIPTION
## Overview

This branch splits into two main themes:

1. profiling infrastructure for repeatable large-input runs
2. pre-write performance work in the CityJSON-to-GLB pipeline

It also adds supporting documentation for the profiling workflow, the performance investigation, and the associated optimization decision record.

## Profiling Workflow

- Added a repo-local `just profile` entrypoint and `scripts/profile-tyler.sh`.
- Integrated profiling by Geodepot case name, where the case spec resolves both:
  - the input dataset path via `geodepot get <case spec>`
  - the case-specific `profile-tyler.json` data item via the case root
- Added support for selecting which profiler runs:
  - `--runner perf`
  - `--runner massif`
  - `--runner all` by default
- Preserved failed profiling runs so long Massif sessions can be inspected without rerunning them.
- Wrote structured per-run output under `docs/performance/runs/` with:
  - `manifest.json`
  - `perf-stat.json`
  - `massif-summary.json`
  - `summary.md`

## Performance Changes

- Reduced allocations in the grid-counting and tile-preparation path.
- Added a faster path for direct unique cell assignment in the grid counter.
- Skipped no-op tile-preparation work when it cannot affect GLB output.
- Added timing and count logging around the main hot spots so future profiling is easier to interpret.
- Improved glTF writer and CLI logging to support debugging and profiling.