### PR TITLE
Parallelise in chunks for extent calc and vertex counting + cache PROJ transform per GLB export worker

### DIFF
--- a/cityjson-convert/src/gltf_writer.rs
+++ b/cityjson-convert/src/gltf_writer.rs
@@ -423,8 +423,8 @@ impl CachedProjTransform {
             let transformer = cache
                 .get(&self.key)
                 .expect("cached PROJ transform should have been inserted");
-            let transformed = transformer.convert((point[0], point[1], point[2]))?;
-            Ok([transformed.0, transformed.1, transformed.2])
+            let converted = transformer.convert((point[0], point[1], point[2]))?;
+            Ok([converted.0, converted.1, converted.2])
         })
     }
 }

--- a/cityjson-convert/src/gltf_writer.rs
+++ b/cityjson-convert/src/gltf_writer.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::too_many_lines)]
 
+use std::cell::RefCell;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::convert::TryFrom;
 use std::fs::File;
@@ -31,6 +32,10 @@ const QUANTIZED_POSITION_STRIDE: usize = std::mem::size_of::<QuantizedPosition>(
 const QUANTIZED_NORMAL_STRIDE: usize = std::mem::size_of::<QuantizedNormal>();
 const CLIP_PLANE_EPSILON: f64 = 1.0e-12;
 const GEOGRAPHIC_CLIP_INTERSECTION_ITERATIONS: usize = 64;
+
+thread_local! {
+    static PROJ_TRANSFORM_CACHE: RefCell<HashMap<(String, String), Proj>> = RefCell::new(HashMap::new());
+}
 
 /// Parse hex color string (#RRGGBB) to RGBA f32 array [R, G, B, A]
 fn hex_to_rgba(hex: &str) -> Result<[f32; 4], anyhow::Error> {
@@ -318,7 +323,7 @@ struct ClipVertex {
 }
 
 struct GeographicClipVolume {
-    transformer: Option<Proj>,
+    transformer: Option<CachedProjTransform>,
     west: f64,
     south: f64,
     east: f64,
@@ -372,11 +377,11 @@ struct CoordinateTransform {
 enum CoordinatePlacement {
     SourceCoordinates,
     EcefRelative {
-        vertex_transformer: Option<Proj>,
+        vertex_transformer: Option<CachedProjTransform>,
         origin: [f64; 3],
     },
     Enu {
-        vertex_transformer: Option<Proj>,
+        vertex_transformer: Option<CachedProjTransform>,
         ecef_origin: [f64; 3],
         east: [f64; 3],
         north: [f64; 3],
@@ -388,6 +393,40 @@ enum CoordinatePlacement {
 struct SmoothVertexKey {
     position_bits: [u32; 3],
     feature_id: u32,
+}
+
+#[derive(Clone, Debug)]
+struct CachedProjTransform {
+    key: (String, String),
+}
+
+impl CachedProjTransform {
+    fn new(source_crs: String, target_crs: &'static str) -> Self {
+        Self {
+            key: (source_crs, target_crs.to_owned()),
+        }
+    }
+
+    fn convert(&self, point: [f64; 3]) -> Result<[f64; 3]> {
+        PROJ_TRANSFORM_CACHE.with(|cache| {
+            let mut cache = cache.borrow_mut();
+            if !cache.contains_key(&self.key) {
+                let transformer = Proj::new_known_crs(&self.key.0, &self.key.1, None)
+                    .with_context(|| {
+                        format!(
+                            "failed to create {} to {} transform",
+                            self.key.0, self.key.1
+                        )
+                    })?;
+                cache.insert(self.key.clone(), transformer);
+            }
+            let transformer = cache
+                .get(&self.key)
+                .expect("cached PROJ transform should have been inserted");
+            let transformed = transformer.convert((point[0], point[1], point[2]))?;
+            Ok([transformed.0, transformed.1, transformed.2])
+        })
+    }
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -526,7 +565,7 @@ impl CoordinateTransform {
             GeometryPlacement::SourceCoordinates => CoordinatePlacement::SourceCoordinates,
             GeometryPlacement::EcefRelative { source_crs, origin } => {
                 let source_crs = canonical_epsg_crs(source_crs)?;
-                let vertex_transformer = source_to_ecef_transformer(&source_crs)?;
+                let vertex_transformer = source_to_ecef_transformer(&source_crs);
                 CoordinatePlacement::EcefRelative {
                     vertex_transformer,
                     origin: *origin,
@@ -540,7 +579,7 @@ impl CoordinateTransform {
                 up,
             } => {
                 let source_crs = canonical_epsg_crs(source_crs)?;
-                let vertex_transformer = source_to_ecef_transformer(&source_crs)?;
+                let vertex_transformer = source_to_ecef_transformer(&source_crs);
                 CoordinatePlacement::Enu {
                     vertex_transformer,
                     ecef_origin: *ecef_origin,
@@ -610,9 +649,7 @@ impl ClipVolume {
     fn geographic_region(region: &GeographicClipRegion) -> Result<Self> {
         let source_crs = canonical_epsg_crs(&region.source_crs)?;
         let transformer = (source_crs != "EPSG:4979")
-            .then(|| Proj::new_known_crs(&source_crs, "EPSG:4979", None))
-            .transpose()
-            .context("failed to create source CRS to EPSG:4979 clip transform")?;
+            .then(|| CachedProjTransform::new(source_crs.clone(), "EPSG:4979"));
         Ok(Self::GeographicRegion(GeographicClipVolume {
             transformer,
             west: region.west,
@@ -629,12 +666,12 @@ impl ClipVolume {
                 let [x, y, z] = source_position;
                 let geographic = if let Some(transformer) = &region.transformer {
                     transformer
-                        .convert((x, y, z))
+                        .convert([x, y, z])
                         .context("failed to project position to EPSG:4979 for clipping")?
                 } else {
-                    (x, y, z)
+                    [x, y, z]
                 };
-                Ok([geographic.0, geographic.1, geographic.2])
+                Ok(geographic)
             }
         }
     }
@@ -778,20 +815,21 @@ fn canonical_epsg_crs(value: &str) -> Result<String> {
     Ok(format!("EPSG:{parsed}"))
 }
 
-fn source_to_ecef_transformer(source_crs: &str) -> Result<Option<Proj>> {
+fn source_to_ecef_transformer(source_crs: &str) -> Option<CachedProjTransform> {
     (source_crs != "EPSG:4978")
-        .then(|| Proj::new_known_crs(source_crs, "EPSG:4978", None))
-        .transpose()
-        .context("failed to create source CRS to ECEF transform")
+        .then(|| CachedProjTransform::new(source_crs.to_owned(), "EPSG:4978"))
 }
 
-fn transform_to_ecef(point: [f64; 3], vertex_transformer: Option<&Proj>) -> Result<[f64; 3]> {
+fn transform_to_ecef(
+    point: [f64; 3],
+    vertex_transformer: Option<&CachedProjTransform>,
+) -> Result<[f64; 3]> {
     let [x, y, z] = point;
     if let Some(transformer) = vertex_transformer {
         let transformed = transformer
-            .convert((x, y, z))
+            .convert([x, y, z])
             .context("failed to project position to ECEF")?;
-        Ok([transformed.0, transformed.1, transformed.2])
+        Ok(transformed)
     } else {
         Ok(point)
     }

--- a/docs/adr/009-cache-proj-transforms-during-glb-export.md
+++ b/docs/adr/009-cache-proj-transforms-during-glb-export.md
@@ -1,0 +1,162 @@
+# Cache PROJ Transforms During GLB Export
+
+## Status
+
+Proposed
+
+## Context
+
+After the grid indexing and feature-preparation optimizations, large
+`BuildingPart` exports still underused CPU during the GLB tile writing phase.
+Rayon had enough tile jobs, and `perf sched` showed that Linux scheduler delay
+was negligible:
+
+- `tyler` accumulated about 328 seconds of CPU runtime across 9 threads
+- average scheduler delay was about 0.010 ms
+- maximum scheduler delay was about 1.476 ms
+
+This ruled out tile-job starvation and OS scheduling as the main cause. The
+process still only consumed about 3.5 to 3.6 CPU cores on average with
+`RAYON_NUM_THREADS=8`, so the missing time had to be blocked/off-CPU time inside
+the tile export work.
+
+`strace -f -c` then showed that the missing time was mostly lock wait:
+
+```text
+85.73%  269.944s  futex
+4.54%    14.305s  lseek
+4.34%    13.678s  read
+2.10%     6.602s  pread64
+```
+
+A futex profile showed almost all futex traffic on one address, but the first
+capture grouped by futex address rather than by owner. A focused userspace
+stack capture of glibc lock waits identified the owner as PROJ's internal
+SQLite-backed authority database:
+
+```text
+__lll_lock_wait
+sqlite3_column_text
+osgeo::proj::io::DatabaseContext::Private::run
+osgeo::proj::io::AuthorityFactory::...
+osgeo::proj::operation::CoordinateOperationFactory::...
+```
+
+The repeated construction happened inside the GLB writer:
+
+- `CoordinateTransform::from_model` created a source-to-ECEF transform with
+  `Proj::new_known_crs(source_crs, "EPSG:4978", None)`
+- `ClipVolume::geographic_region` optionally created a source-to-geographic
+  transform with `Proj::new_known_crs(source_crs, "EPSG:4979", None)`
+
+Both were called per tile. For 598 tiles, this caused many parallel requests for
+the same CRS operations. PROJ responded by repeatedly querying its internal
+authority database and serializing on its own SQLite/glibc locks.
+
+## Decision
+
+`cityjson-convert` will cache constructed PROJ transforms per worker thread
+during GLB export.
+
+The GLB writer now stores lightweight transform specifications in tile-local
+state rather than owning `Proj` values directly:
+
+- `CachedProjTransform` stores the `(source_crs, target_crs)` key.
+- A thread-local `HashMap<(String, String), Proj>` stores the actual PROJ
+  objects.
+- `CachedProjTransform::convert` creates the PROJ object on first use in that
+  worker thread, then reuses it for subsequent vertex conversions.
+
+This applies to:
+
+- source CRS to ECEF (`EPSG:4978`) for ENU / ECEF-relative GLB placement
+- source CRS to geographic (`EPSG:4979`) for geographic clipping
+
+The cache is thread-local rather than global because `Proj` wraps raw PROJ
+context/object pointers and should not be shared across threads without a
+separate thread-safety audit. Thread-local caching matches the Rayon execution
+model: each worker pays the expensive PROJ operation construction once per CRS
+pair, then reuses it for many tiles.
+
+No CLI behavior or output semantics change.
+
+## Consequences
+
+Good:
+
+- repeated per-tile PROJ operation construction is avoided
+- PROJ's internal SQLite authority database should no longer dominate futex
+  wait time after the first few tiles per worker
+- the fix is local to `cityjson-convert` and preserves the existing
+  `convert_to_glb(&CityModel, path, &ExportOptions)` API
+- transform construction errors still surface at conversion time with source
+  and target CRS context
+
+Trade-offs:
+
+- transform creation is now lazy, so an invalid CRS may fail on first vertex
+  conversion instead of at `CoordinateTransform::from_model`
+- each worker keeps its own copy of each used transform, so memory usage grows
+  with `RAYON_NUM_THREADS * number_of_CRS_pairs`
+- a long-lived worker thread may retain cached PROJ objects until the thread
+  exits
+- this does not remove the cost of `proj_trans` itself; it only removes repeated
+  `proj_create_crs_to_crs` / authority lookup overhead
+
+## Rejected Alternatives
+
+- Use a single global `Mutex<HashMap<...>>` of `Proj` values.
+  This would likely move the bottleneck from PROJ's internal locks to Tyler's
+  own lock, and sharing raw PROJ objects across threads would need an explicit
+  safety audit.
+
+- Pre-create transforms once in `src/main.rs` and pass them through
+  `ExportOptions`.
+  This would require widening public API and threading lifetime/ownership
+  concerns through the caller. It is heavier than needed because the problem is
+  local to GLB conversion.
+
+- Create one transform per tile but serialize transform creation.
+  This would reduce PROJ lock contention but still perform the expensive
+  authority lookup hundreds of times.
+
+- Replace PROJ with a hand-coded transform for the observed CRS pair.
+  That may be faster for one dataset, but it would be brittle and would bypass
+  PROJ's CRS semantics, grid handling, and future datasets.
+
+## Validation Plan
+
+Functional validation:
+
+- run `cargo fmt --all --check`
+- run `cargo check --workspace --all-targets --all-features`
+- run `cargo test --workspace --all-targets --all-features`
+- keep existing GLB writer tests for:
+  - ENU placement
+  - ECEF reprojection
+  - geographic clipping
+  - geographic clip intersection solving
+
+Performance validation:
+
+- rerun the Amsterdam subset export with `RAYON_NUM_THREADS=8`
+- compare the `Converting and optimizing ... tiles` wall time before and after
+- rerun `strace -f -c` and confirm futex time is materially reduced
+- rerun the glibc lock-wait stack capture and confirm PROJ authority database
+  stacks are no longer dominant
+- compare the GLB tile export wall time before and after the cache change
+
+Expected profiling change:
+
+- far fewer stacks under `osgeo::proj::io::DatabaseContext::Private::run`
+- far fewer `sqlite3_column_text` / PROJ authority factory lock waits
+- no meaningful change to CityJSON decode, feature preparation, or meshopt
+  costs
+
+## Notes
+
+The first measurement after this change should still show a small amount of
+PROJ authority database work: each Rayon worker must build its own cached
+source-to-ECEF transform, and clipping may add a cached source-to-geographic
+transform. The goal is to reduce that cost from "once per tile" to "once per
+worker per CRS pair".

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -30,6 +30,7 @@ use serde::{Deserialize, Serialize};
 use crate::spatial_structs::{Bbox, Cell, CellId};
 
 const CJINDEX_PAGE_SIZE: usize = 65_536;
+const CJINDEX_PARALLEL_CHUNK_SIZE: usize = 2_048;
 const LARGE_FEATURE_VERTEX_COUNT_THRESHOLD: usize = 50_000;
 
 thread_local! {
@@ -60,6 +61,51 @@ struct SelectedGeometryStats {
     selected_vertices: Vec<GeometryVertexIndex<u32>>,
     selected_object_types: Vec<CityObjectType>,
     ignored_object_types: Vec<CityObjectType>,
+}
+
+#[derive(Default)]
+struct ExtentStats {
+    extent: Option<Bbox>,
+    nr_features: usize,
+    nr_features_ignored: usize,
+    cityobject_types_ignored: Vec<CityObjectType>,
+}
+
+impl ExtentStats {
+    fn add_selected_geometry_stats(&mut self, stats: SelectedGeometryStats) {
+        if let Some(model_bbox) = stats.bbox {
+            if let Some(current) = self.extent.as_mut() {
+                merge_bbox(current, &model_bbox);
+            } else {
+                self.extent = Some(model_bbox);
+            }
+            self.nr_features += 1;
+        } else {
+            self.nr_features_ignored += 1;
+            self.extend_ignored_types(stats.ignored_object_types);
+        }
+    }
+
+    fn merge(&mut self, other: Self) {
+        if let Some(other_extent) = other.extent {
+            if let Some(current) = self.extent.as_mut() {
+                merge_bbox(current, &other_extent);
+            } else {
+                self.extent = Some(other_extent);
+            }
+        }
+        self.nr_features += other.nr_features;
+        self.nr_features_ignored += other.nr_features_ignored;
+        self.extend_ignored_types(other.cityobject_types_ignored);
+    }
+
+    fn extend_ignored_types(&mut self, ignored_types: Vec<CityObjectType>) {
+        for cotype in ignored_types {
+            if !self.cityobject_types_ignored.contains(&cotype) {
+                self.cityobject_types_ignored.push(cotype);
+            }
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -139,7 +185,11 @@ impl World {
             if cityobject_types.is_none() {
                 Self::extent_from_cjindex_bbox_pages(&city_index)?
             } else {
-                Self::extent_from_cjindex_features(&city_index, cityobject_types.as_ref())?
+                Self::extent_from_cjindex_features(
+                    &input_source,
+                    &city_index,
+                    cityobject_types.as_ref(),
+                )?
             };
 
         let mut extent = extent.ok_or_else(|| {
@@ -203,43 +253,49 @@ impl World {
     }
 
     fn extent_from_cjindex_features(
+        input_source: &InputSource,
         city_index: &CityIndex,
         cityobject_types: Option<&Vec<CityObjectType>>,
     ) -> Result<(Option<Bbox>, usize, usize, Vec<CityObjectType>), Box<dyn std::error::Error>> {
-        let mut extent: Option<Bbox> = None;
-        let mut nr_features = 0usize;
-        let mut nr_features_ignored = 0usize;
-        let mut cityobject_types_ignored: Vec<CityObjectType> = Vec::new();
+        let mut total = ExtentStats::default();
 
         for page_result in city_index.iter_all_feature_ref_pages(CJINDEX_PAGE_SIZE)? {
             let page = page_result?;
-            for feature in page {
-                let model = city_index.read_feature(&feature)?;
-                let stats = selected_geometry_stats(&model, cityobject_types);
-                if let Some(model_bbox) = stats.bbox {
-                    if let Some(current) = extent.as_mut() {
-                        merge_bbox(current, &model_bbox);
-                    } else {
-                        extent = Some(model_bbox);
-                    }
-                    nr_features += 1;
-                } else {
-                    nr_features_ignored += 1;
-                    for cotype in stats.ignored_object_types {
-                        if !cityobject_types_ignored.contains(&cotype) {
-                            cityobject_types_ignored.push(cotype);
-                        }
-                    }
-                }
+            let chunk_results = page
+                .par_chunks(CJINDEX_PARALLEL_CHUNK_SIZE)
+                .map(|feature_refs| {
+                    Self::extent_from_cjindex_feature_refs_chunk(
+                        input_source,
+                        feature_refs,
+                        cityobject_types,
+                    )
+                })
+                .collect::<Vec<_>>();
+            for chunk in chunk_results {
+                total.merge(chunk?);
             }
         }
 
         Ok((
-            extent,
-            nr_features,
-            nr_features_ignored,
-            cityobject_types_ignored,
+            total.extent,
+            total.nr_features,
+            total.nr_features_ignored,
+            total.cityobject_types_ignored,
         ))
+    }
+
+    fn extent_from_cjindex_feature_refs_chunk(
+        input_source: &InputSource,
+        feature_refs: &[cityjson_index::IndexedFeatureRef],
+        cityobject_types: Option<&Vec<CityObjectType>>,
+    ) -> Result<ExtentStats, std::io::Error> {
+        let models = Self::read_cjindex_features_thread_local(input_source, feature_refs)
+            .map_err(|error| std::io::Error::other(error.to_string()))?;
+        let mut chunk = ExtentStats::default();
+        for model in models {
+            chunk.add_selected_geometry_stats(selected_geometry_stats(&model, cityobject_types));
+        }
+        Ok(chunk)
     }
 
     fn cjindex_bounds_to_world_bbox(bounds: &cityjson_index::FeatureBounds) -> Bbox {
@@ -294,23 +350,20 @@ impl World {
         let mut scanned_features = 0usize;
         let mut indexed_features = 0usize;
         let started = Instant::now();
-        for page_result in city_index.scan_feature_pages(CJINDEX_PAGE_SIZE)? {
+        for page_result in city_index.iter_all_feature_ref_pages(CJINDEX_PAGE_SIZE)? {
             let page_started = Instant::now();
             let page = page_result?;
             page_count += 1;
             scanned_features += page.len();
             let feature_in_cells = page
-                .into_par_iter()
-                .map(|feature| -> Option<FeatureInGridCells> {
-                    self.index_feature_model(
-                        FeatureReference::CjIndexRef(feature.reference),
-                        &feature.model,
-                    )
-                })
+                .par_chunks(CJINDEX_PARALLEL_CHUNK_SIZE)
+                .map(|feature_refs| self.index_cjindex_feature_refs_chunk(feature_refs))
                 .collect::<Vec<_>>();
-            for feature_in_cells in feature_in_cells.into_iter().flatten() {
-                indexed_features += 1;
-                self.integrate_feature_in_cells(feature_in_cells);
+            for chunk_result in feature_in_cells {
+                for feature_in_cells in chunk_result?.into_iter().flatten() {
+                    indexed_features += 1;
+                    self.integrate_feature_in_cells(feature_in_cells);
+                }
             }
             debug!(
                 "Indexed cjindex feature page {page_count} in {:?} ({} scanned, {} retained so far)",
@@ -327,6 +380,22 @@ impl World {
             started.elapsed()
         );
         Ok(())
+    }
+
+    fn index_cjindex_feature_refs_chunk(
+        &self,
+        feature_refs: &[cityjson_index::IndexedFeatureRef],
+    ) -> Result<Vec<Option<FeatureInGridCells>>, std::io::Error> {
+        let models = Self::read_cjindex_features_thread_local(&self.input_source, feature_refs)
+            .map_err(|error| std::io::Error::other(error.to_string()))?;
+        Ok(feature_refs
+            .iter()
+            .cloned()
+            .zip(models.iter())
+            .map(|(feature_ref, model)| {
+                self.index_feature_model(FeatureReference::CjIndexRef(feature_ref), model)
+            })
+            .collect())
     }
 
     fn index_feature_model(


### PR DESCRIPTION
Extent calculation now uses cjindex ref pages, splits each page into 2_048-feature chunks, and processes those chunks with Rayon using thread-local CityIndex readers. Grid indexing now does the same: it no longer serially decodes a full page before parallel processing; decoding plus selected_geometry_stats plus vertex counting now happen per parallel chunk.
The final grid integration is still serial because it assigns stable feature ids and mutates the dense grid. That part should be much smaller than decoding/stat/ counting, and keeping it serial preserves output order.

This gives me a 30% speedup with 8 threads for the ams-up data.

Next was an issue with PROJ that was reinitialising the CRS transform for the GLB writer for every tile. This was fixed by doing this once per worker and then caching and reusing it.

That gave another speedup of ~60-70%.

A bit more details in ADR 009. Overal this brought down the processing time from 1m59 to 27s.