### PR TITLE
Further improve cpu utilisation in extent calc and vtx counting

### DIFF
--- a/cityjson-convert/src/gltf_writer.rs
+++ b/cityjson-convert/src/gltf_writer.rs
@@ -423,8 +423,8 @@ impl CachedProjTransform {
             let transformer = cache
                 .get(&self.key)
                 .expect("cached PROJ transform should have been inserted");
-            let converted = transformer.convert((point[0], point[1], point[2]))?;
-            Ok([converted.0, converted.1, converted.2])
+            let output = transformer.convert((point[0], point[1], point[2]))?;
+            Ok([output.0, output.1, output.2])
         })
     }
 }

--- a/docs/adr/010-stream-cjindex-pages-into-pipelined-grid-population.md
+++ b/docs/adr/010-stream-cjindex-pages-into-pipelined-grid-population.md
@@ -1,0 +1,203 @@
+# Stream cjindex Pages into a Pipelined Grid Population
+
+## Status
+
+Proposed
+
+## Related Commits
+
+- `36b2071` Parallelise in chunks for extent calc and vertex counting
+
+## Context
+
+After ADR 005 reduced full extent scans and ADR 008 cut allocations in the
+grid-population path, the extent and vertex-counting phases were further
+parallelised by chunking each `cjindex` page across rayon workers (commit
+`36b2071`). On a 32-core EPYC 7542 running with 20 rayon workers, that change
+roughly halved the wall time of both phases, but `cpustat` showed a pronounced
+oscillation between roughly 100 % and 2000 % CPU usage throughout the phase
+rather than sustained ~2000 % saturation.
+
+The cause was a fan-out/fan-in shape inside `World::index_with_grid`:
+
+```text
+for page in cjindex_pages {                  // (A) serial: load page index
+    let chunks = page.par_chunks(N)          // (B) parallel: rayon workers
+        .map(process_chunk)
+        .collect::<Vec<_>>();
+    for chunk in chunks {
+        for fic in chunk?.into_iter().flatten() {
+            self.integrate_feature_in_cells(fic);  // (C) serial: needs &mut self
+        }
+    }
+}
+```
+
+Each 65 536-feature page hit a hard barrier sequence A → B → C → A → B → C.
+The 100 % troughs in the CPU graph correspond to phases A (page load) and C
+(integration into the dense grid). C is non-trivial: for every retained
+feature, the integrator pushes into `World::features` and mutates
+`grid.cell_mut(...)` for each cell the feature touches. While C runs, all
+rayon workers idle.
+
+`extent_from_cjindex_features` had the same per-page barrier shape, although
+its serial tail (`ExtentStats::merge`) is much cheaper than grid integration
+and only contributed a brief trough.
+
+A first attempt removed the per-page barrier by collecting all pages into a
+single flat `Vec` of chunk slices and running one big `par_iter()`. That
+flattened the per-page A↔B oscillation but introduced a new visible 100 %
+phase at the start of each phase: the entire `cjindex` page index had to be
+materialised serially before any rayon worker could begin.
+
+## Decision
+
+Tyler will run `index_with_grid` and `extent_from_cjindex_features` as
+streaming pipelines under `std::thread::scope`, so that page loading,
+parallel chunk processing, and the serial tail run concurrently.
+
+For `index_with_grid` this is a 3-stage pipeline:
+
+1. **Page loader thread** streams `cjindex` pages from
+   `iter_all_feature_ref_pages(CJINDEX_PAGE_SIZE)`, splits each page into
+   `CJINDEX_PARALLEL_CHUNK_SIZE` slices, clones each slice into an owned
+   `Vec<IndexedFeatureRef>`, and pushes it to a bounded `sync_channel`.
+2. **Worker stage** runs `chunk_rx.into_iter().par_bridge()` on a second
+   scope thread. Each chunk parses its features, counts vertices in cells,
+   and pushes its `Vec<Option<FeatureInGridCells>>` to a second
+   `sync_channel`.
+3. **Integrator (main thread)** drains the result channel and applies
+   mutations to `features` and `grid`.
+
+`extent_from_cjindex_features` uses the same page-loader stage but collapses
+the worker and reduce stages: the main thread runs
+`chunk_rx.into_iter().par_bridge().map(process).try_reduce(ExtentStats::default, merge)`
+because `ExtentStats::merge` is associative and cheap enough that no
+dedicated integrator thread is needed.
+
+To make this representable to the borrow checker without `Mutex`-wrapping
+the grid, two supporting refactors were required:
+
+- A new `GridLayout` snapshot struct in `crate::spatial_structs` exposes the
+  read-only spatial queries used by workers (`locate_point`,
+  `intersect_bbox_ranges`, `intersect_bbox`). It is a `Copy` projection of
+  `SquareGrid`'s metadata, so workers can hold it by value while the
+  integrator keeps `&mut SquareGrid` for cell mutation.
+- `World::index_feature_model` and `World::index_cjindex_feature_refs_chunk`
+  no longer take `&self`. They take `&InputSource`, `&GridLayout`, and
+  `Option<&Vec<CityObjectType>>` directly, so `index_with_grid` can split
+  the `&mut self` borrow into disjoint field borrows.
+
+The bounded `sync_channel(64)` between stages provides back-pressure: if
+the integrator falls behind, the worker stage blocks, which in turn blocks
+the page loader. Memory use is therefore bounded by the channel capacity
+rather than by the number of pages on disk.
+
+The redundant `if !grid_cell.feature_ids.contains(&fid)` guard inside
+`integrate_feature_in_cells` was also removed. `fid` is freshly allocated
+per feature and `feature_in_cells.cells` already contains unique cellids
+(produced by `compress_vertex_counts`), so the guard could never trip.
+
+## Consequences
+
+Good:
+
+- workers can begin processing as soon as the first chunk is loaded; there
+  is no longer a serial pre-collection phase
+- grid integration now overlaps with worker chunk processing, removing the
+  per-page C trough
+- page index I/O runs on a dedicated OS thread, separate from the rayon
+  CPU pool, so I/O does not steal a worker slot
+- back-pressure through `sync_channel(64)` keeps memory bounded; we do not
+  buffer the whole dataset's `IndexedFeatureRef`s in memory
+- `GridLayout` is a small, `Copy` value, so passing it to workers is
+  allocation-free per call
+
+Trade-offs:
+
+- the page loader now clones each chunk into an owned
+  `Vec<IndexedFeatureRef>` so it can cross the channel; with
+  `CJINDEX_PARALLEL_CHUNK_SIZE = 2048` this is a small per-chunk allocation
+  and string clone, but is non-zero
+- `par_bridge` adds a mutex-guarded `next()` call per chunk; with chunk
+  sizes in the thousands of features the per-chunk overhead is negligible
+  relative to feature parsing
+- the integrator path is now a free function `integrate_feature_in_cells`
+  taking `&mut FeatureSet` and `&mut SquareGrid` rather than a method on
+  `World`; this is a small API shape change
+- error handling now flows through `std::io::Error` boxes from the
+  page-loader and worker channels, rather than propagating native
+  `cityjson_lib::Error` and `cityjson_index` errors directly
+
+Neutral:
+
+- `extent_from_cjindex_features` no longer accepts a `&CityIndex`; it opens
+  its own index via `InputSource::open_index` so the index can be moved
+  into the page-loader thread without the `Sync` requirement
+  (`rusqlite::Connection` is `Send` but not `Sync`)
+
+## Rejected Alternatives
+
+- Wrap the cell data in atomics or a sharded mutex so the integrator can
+  also be parallelised. The dense grid is up to 1024 × 1024 ≈ 1 M cells,
+  each holding `nr_vertices: usize` and `feature_ids: Vec<usize>`. Atomics
+  could serve `nr_vertices`, but `feature_ids` would still need a mutex
+  per shard. The pipeline change here is structurally simpler and already
+  removes the dominant C trough; sharding can be revisited if profiling
+  later shows the integrator as the next bottleneck.
+
+- Pre-collect all `IndexedFeatureRef` pages into one flat `Vec` and run
+  `par_iter()` on it. This was the first iteration of the change. It
+  removes the per-page A↔B↔C oscillation but introduces a long serial
+  page-collection prefix at the start of each phase, which was visible as
+  a ~100 % CPU phase before the parallel work started.
+
+- Use `rayon::scope` instead of `std::thread::scope` for the spawned
+  stages. `rayon::scope` blocks the calling task until all child tasks
+  complete, which would defeat the goal of overlapping page loading with
+  chunk processing. `std::thread::scope` runs the stages on dedicated OS
+  threads while still allowing borrows from the enclosing function.
+
+- Use `rayon::spawn` to fire-and-forget chunk tasks. `rayon::spawn`
+  requires `'static` closures, which would force `Arc` wrapping of
+  `InputSource`, `GridLayout`, and the type filter. The
+  `std::thread::scope` formulation lets these be ordinary borrows.
+
+## Validation Plan
+
+Functional validation:
+
+- run `cargo fmt --all --check`
+- run `cargo check --workspace --all-targets --all-features`
+- run `cargo test --workspace --all-targets --all-features`
+- keep existing parser tests for:
+  - unique-assignment cell selection
+  - bbox-spanning vs. vertex-bearing cell counts
+  - `count_vertices_in_grid` parity with the reference `BTreeMap`
+    implementation
+
+Performance validation:
+
+- rerun the same dataset that produced the 100 %/2000 % oscillation
+  (Amsterdam-scale `cjindex` with `--cityobject-types Building`)
+- confirm with `cpustat` that the extent and vertex-counting phases
+  sustain ~2000 % CPU usage across the rayon pool, with only a brief
+  startup blip while the first chunk is being loaded
+- confirm wall-time is at least as good as the per-page parallel
+  baseline from `36b2071`
+
+Expected profiling change:
+
+- the per-page CPU trough during integration disappears
+- the prefix CPU trough caused by serial page pre-collection disappears
+- there is no measurable change in CityJSON decode time or PROJ behavior
+  (those are addressed by ADRs 005, 008, and 009)
+
+## Notes
+
+The integrator stage still runs on a single thread, by design: the dense
+grid mutations and the `features` `Vec` push are serialised. The win here
+is overlapping that serial work with chunk processing, not eliminating it.
+If a future profile shows the integrator as the next dominant cost, the
+cell-storage refactor described under "Rejected Alternatives" would be the
+next step.

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -27,7 +27,7 @@ use log::{debug, info};
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 
-use crate::spatial_structs::{Bbox, Cell, CellId};
+use crate::spatial_structs::{Bbox, Cell, CellId, GridLayout};
 
 const CJINDEX_PAGE_SIZE: usize = 65_536;
 const CJINDEX_PARALLEL_CHUNK_SIZE: usize = 2_048;
@@ -180,16 +180,12 @@ impl World {
             cityobject_types
         );
 
-        let city_index = input_source.open_index()?;
         let (extent, nr_features, nr_features_ignored, cityobject_types_ignored) =
             if cityobject_types.is_none() {
+                let city_index = input_source.open_index()?;
                 Self::extent_from_cjindex_bbox_pages(&city_index)?
             } else {
-                Self::extent_from_cjindex_features(
-                    &input_source,
-                    &city_index,
-                    cityobject_types.as_ref(),
-                )?
+                Self::extent_from_cjindex_features(&input_source, cityobject_types.as_ref())?
             };
 
         let mut extent = extent.ok_or_else(|| {
@@ -254,27 +250,50 @@ impl World {
 
     fn extent_from_cjindex_features(
         input_source: &InputSource,
-        city_index: &CityIndex,
         cityobject_types: Option<&Vec<CityObjectType>>,
     ) -> Result<(Option<Bbox>, usize, usize, Vec<CityObjectType>), Box<dyn std::error::Error>> {
-        let mut total = ExtentStats::default();
+        let city_index = input_source.open_index()?;
+        let (chunk_tx, chunk_rx) =
+            std::sync::mpsc::sync_channel::<Vec<cityjson_index::IndexedFeatureRef>>(64);
 
-        for page_result in city_index.iter_all_feature_ref_pages(CJINDEX_PAGE_SIZE)? {
-            let page = page_result?;
-            let chunk_results = page
-                .par_chunks(CJINDEX_PARALLEL_CHUNK_SIZE)
-                .map(|feature_refs| {
+        // Same 2-stage pipeline as `index_with_grid`: a dedicated page-loader
+        // thread streams owned chunks to `chunk_tx` so workers can start
+        // processing before all pages have been read.
+        let total = std::thread::scope(|s| -> Result<ExtentStats, std::io::Error> {
+            let page_loader = s.spawn(move || -> Result<(), std::io::Error> {
+                let pages_iter = city_index
+                    .iter_all_feature_ref_pages(CJINDEX_PAGE_SIZE)
+                    .map_err(|e| std::io::Error::other(e.to_string()))?;
+                for page_result in pages_iter {
+                    let page =
+                        page_result.map_err(|e| std::io::Error::other(e.to_string()))?;
+                    for chunk in page.chunks(CJINDEX_PARALLEL_CHUNK_SIZE) {
+                        if chunk_tx.send(chunk.to_vec()).is_err() {
+                            return Ok(());
+                        }
+                    }
+                }
+                Ok(())
+            });
+
+            let total = chunk_rx
+                .into_iter()
+                .par_bridge()
+                .map(|chunk| {
                     Self::extent_from_cjindex_feature_refs_chunk(
                         input_source,
-                        feature_refs,
+                        &chunk,
                         cityobject_types,
                     )
                 })
-                .collect::<Vec<_>>();
-            for chunk in chunk_results {
-                total.merge(chunk?);
-            }
-        }
+                .try_reduce(ExtentStats::default, |mut a, b| {
+                    a.merge(b);
+                    Ok(a)
+                })?;
+
+            page_loader.join().expect("page loader thread panicked")?;
+            Ok(total)
+        })?;
 
         Ok((
             total.extent,
@@ -345,36 +364,100 @@ impl World {
         info!("Counting vertices in grid cells");
 
         self.features.clear();
-        let city_index = self.input_source.open_index()?;
-        let mut page_count = 0usize;
-        let mut scanned_features = 0usize;
-        let mut indexed_features = 0usize;
         let started = Instant::now();
-        for page_result in city_index.iter_all_feature_ref_pages(CJINDEX_PAGE_SIZE)? {
-            let page_started = Instant::now();
-            let page = page_result?;
-            page_count += 1;
-            scanned_features += page.len();
-            let feature_in_cells = page
-                .par_chunks(CJINDEX_PARALLEL_CHUNK_SIZE)
-                .map(|feature_refs| self.index_cjindex_feature_refs_chunk(feature_refs))
-                .collect::<Vec<_>>();
-            for chunk_result in feature_in_cells {
-                for feature_in_cells in chunk_result?.into_iter().flatten() {
-                    indexed_features += 1;
-                    self.integrate_feature_in_cells(feature_in_cells);
+        let city_index = self.input_source.open_index()?;
+
+        // Split the &mut self borrow into disjoint field borrows so workers can
+        // hold immutable views (input_source, grid_layout, cityobject_types)
+        // while the integrator mutates `features` and `grid`.
+        let features: &mut FeatureSet = &mut self.features;
+        let grid: &mut crate::spatial_structs::SquareGrid = &mut self.grid;
+        let input_source: &InputSource = &self.input_source;
+        let cityobject_types: Option<&Vec<CityObjectType>> = self.cityobject_types.as_ref();
+        let grid_layout = grid.layout();
+
+        type ChunkResult = Result<Vec<Option<FeatureInGridCells>>, std::io::Error>;
+        let (chunk_tx, chunk_rx) =
+            std::sync::mpsc::sync_channel::<Vec<cityjson_index::IndexedFeatureRef>>(64);
+        let (result_tx, result_rx) = std::sync::mpsc::sync_channel::<ChunkResult>(64);
+
+        let mut indexed_features = 0usize;
+        let mut consumer_err: Option<std::io::Error> = None;
+
+        // 3-stage pipeline:
+        //   Stage 1 (page_loader): streams pages from cjindex and pushes owned
+        //     chunks to chunk_tx. Runs on its own OS thread so I/O overlaps with
+        //     CPU work in the rayon pool.
+        //   Stage 2 (workers): par_bridge consumes chunk_rx and dispatches each
+        //     chunk to a rayon worker, which parses the features, counts vertices
+        //     in cells, and pushes the result to result_tx.
+        //   Stage 3 (integrator, main thread): drains result_rx and applies the
+        //     mutations to `features` and `grid`.
+        let loader_outcome = std::thread::scope(
+            |s| -> Result<(usize, usize), std::io::Error> {
+                let page_loader = s.spawn(move || -> Result<(usize, usize), std::io::Error> {
+                    let pages_iter = city_index
+                        .iter_all_feature_ref_pages(CJINDEX_PAGE_SIZE)
+                        .map_err(|e| std::io::Error::other(e.to_string()))?;
+                    let mut page_count = 0usize;
+                    let mut scanned_features = 0usize;
+                    for page_result in pages_iter {
+                        let page =
+                            page_result.map_err(|e| std::io::Error::other(e.to_string()))?;
+                        page_count += 1;
+                        scanned_features += page.len();
+                        for chunk in page.chunks(CJINDEX_PARALLEL_CHUNK_SIZE) {
+                            if chunk_tx.send(chunk.to_vec()).is_err() {
+                                return Ok((page_count, scanned_features));
+                            }
+                        }
+                    }
+                    Ok((page_count, scanned_features))
+                });
+
+                s.spawn(move || {
+                    chunk_rx
+                        .into_iter()
+                        .par_bridge()
+                        .for_each_with(result_tx, |tx, chunk| {
+                            let result = Self::index_cjindex_feature_refs_chunk(
+                                input_source,
+                                &grid_layout,
+                                cityobject_types,
+                                &chunk,
+                            );
+                            let _ = tx.send(result);
+                        });
+                });
+
+                while let Ok(result) = result_rx.recv() {
+                    match result {
+                        Ok(fics) => {
+                            for fic in fics.into_iter().flatten() {
+                                indexed_features += 1;
+                                integrate_feature_in_cells(features, grid, fic);
+                            }
+                        }
+                        Err(e) => {
+                            if consumer_err.is_none() {
+                                consumer_err = Some(e);
+                            }
+                        }
+                    }
                 }
-            }
-            debug!(
-                "Indexed cjindex feature page {page_count} in {:?} ({} scanned, {} retained so far)",
-                page_started.elapsed(),
-                scanned_features,
-                indexed_features
-            );
+
+                page_loader.join().expect("page loader thread panicked")
+            },
+        );
+
+        if let Some(e) = consumer_err {
+            return Err(Box::new(e));
         }
+        let (page_count, scanned_features) = loader_outcome?;
+
         info!(
             "Indexed {} of {} scanned features into grid cells across {} pages in {:?}",
-            self.features.len(),
+            features.len(),
             scanned_features,
             page_count,
             started.elapsed()
@@ -383,28 +466,36 @@ impl World {
     }
 
     fn index_cjindex_feature_refs_chunk(
-        &self,
+        input_source: &InputSource,
+        grid_layout: &GridLayout,
+        cityobject_types: Option<&Vec<CityObjectType>>,
         feature_refs: &[cityjson_index::IndexedFeatureRef],
     ) -> Result<Vec<Option<FeatureInGridCells>>, std::io::Error> {
-        let models = Self::read_cjindex_features_thread_local(&self.input_source, feature_refs)
+        let models = Self::read_cjindex_features_thread_local(input_source, feature_refs)
             .map_err(|error| std::io::Error::other(error.to_string()))?;
         Ok(feature_refs
             .iter()
             .cloned()
             .zip(models.iter())
             .map(|(feature_ref, model)| {
-                self.index_feature_model(FeatureReference::CjIndexRef(feature_ref), model)
+                Self::index_feature_model(
+                    grid_layout,
+                    cityobject_types,
+                    FeatureReference::CjIndexRef(feature_ref),
+                    model,
+                )
             })
             .collect())
     }
 
     fn index_feature_model(
-        &self,
+        grid_layout: &GridLayout,
+        cityobject_types: Option<&Vec<CityObjectType>>,
         feature_reference: FeatureReference,
         model: &cityjson_lib::CityModel,
     ) -> Option<FeatureInGridCells> {
         let stats_started = Instant::now();
-        let stats = selected_geometry_stats(model, self.cityobject_types.as_ref());
+        let stats = selected_geometry_stats(model, cityobject_types);
         debug!(
             "selected_geometry_stats collected {} vertices for {:?} in {:?}",
             stats.selected_vertices.len(),
@@ -426,7 +517,7 @@ impl World {
         if uses_unique_assignment {
             let count_started = Instant::now();
             let (cellid, nr_vertices) =
-                count_unique_assignment_cell(model, &stats.selected_vertices, &self.grid, &bbox)?;
+                count_unique_assignment_cell(model, &stats.selected_vertices, grid_layout, &bbox)?;
             debug!(
                 "Selected unique assignment grid cell {:?} with {} vertices in {:?}",
                 cellid,
@@ -438,7 +529,7 @@ impl World {
 
         let count_started = Instant::now();
         let cell_vtx_cnt =
-            count_vertices_in_grid(model, &stats.selected_vertices, &self.grid, &bbox);
+            count_vertices_in_grid(model, &stats.selected_vertices, grid_layout, &bbox);
         debug!(
             "Counted {} grid cells for {:?} in {:?}",
             cell_vtx_cnt.len(),
@@ -449,18 +540,6 @@ impl World {
             return None;
         }
         Self::feature_to_cells(feature, cell_vtx_cnt)
-    }
-
-    fn integrate_feature_in_cells(&mut self, feature_in_cells: FeatureInGridCells) {
-        let fid = self.features.len();
-        self.features.push(feature_in_cells.feature);
-        for (cellid, cell) in feature_in_cells.cells {
-            let grid_cell = self.grid.cell_mut(&cellid);
-            grid_cell.nr_vertices += cell.nr_vertices;
-            if !grid_cell.feature_ids.contains(&fid) {
-                grid_cell.feature_ids.push(fid)
-            }
-        }
     }
 
     fn feature_to_cells(feature: Feature, cell_vtx_cnt: CellCounts) -> Option<FeatureInGridCells> {
@@ -518,6 +597,20 @@ impl World {
             Some(outdir) => File::create(outdir.join(format!("{file_name}.bincode")))?,
         };
         bincode::serialize_into(file, self)
+    }
+}
+
+fn integrate_feature_in_cells(
+    features: &mut FeatureSet,
+    grid: &mut crate::spatial_structs::SquareGrid,
+    feature_in_cells: FeatureInGridCells,
+) {
+    let fid = features.len();
+    features.push(feature_in_cells.feature);
+    for (cellid, cell) in feature_in_cells.cells {
+        let grid_cell = grid.cell_mut(&cellid);
+        grid_cell.nr_vertices += cell.nr_vertices;
+        grid_cell.feature_ids.push(fid);
     }
 }
 
@@ -737,7 +830,7 @@ fn collect_selected_vertex_indices(
 fn count_vertices_in_grid(
     model: &cityjson::v2_0::OwnedCityModel,
     selected_vertices: &[GeometryVertexIndex<u32>],
-    grid: &crate::spatial_structs::SquareGrid,
+    grid: &GridLayout,
     bbox: &Bbox,
 ) -> CellCounts {
     if selected_vertices.is_empty() {
@@ -760,7 +853,7 @@ fn count_vertices_in_grid(
 fn count_unique_assignment_cell(
     model: &cityjson::v2_0::OwnedCityModel,
     selected_vertices: &[GeometryVertexIndex<u32>],
-    grid: &crate::spatial_structs::SquareGrid,
+    grid: &GridLayout,
     bbox: &Bbox,
 ) -> Option<(CellId, usize)> {
     if selected_vertices.is_empty() {
@@ -787,7 +880,7 @@ fn count_unique_assignment_cell(
 fn count_vertex_cells(
     model: &cityjson::v2_0::OwnedCityModel,
     selected_vertices: &[GeometryVertexIndex<u32>],
-    grid: &crate::spatial_structs::SquareGrid,
+    grid: &GridLayout,
 ) -> Vec<(CellId, usize)> {
     let mut vertex_counts = Vec::with_capacity(selected_vertices.len());
     count_vertex_cells_into(model, selected_vertices, grid, &mut vertex_counts);
@@ -797,7 +890,7 @@ fn count_vertex_cells(
 fn count_vertex_cells_into(
     model: &cityjson::v2_0::OwnedCityModel,
     selected_vertices: &[GeometryVertexIndex<u32>],
-    grid: &crate::spatial_structs::SquareGrid,
+    grid: &GridLayout,
     vertex_counts: &mut Vec<(CellId, usize)>,
 ) {
     vertex_counts.clear();
@@ -850,7 +943,7 @@ fn compress_vertex_counts(vertex_counts: &mut Vec<(CellId, usize)>) {
 fn count_vertex_cells_parallel(
     model: &cityjson::v2_0::OwnedCityModel,
     selected_vertices: &[GeometryVertexIndex<u32>],
-    grid: &crate::spatial_structs::SquareGrid,
+    grid: &GridLayout,
 ) -> Vec<(CellId, usize)> {
     let vertices = model.vertices();
     selected_vertices
@@ -870,7 +963,7 @@ fn count_vertex_cells_parallel(
 
 fn max_merged_vertex_count_with_bbox(
     vertex_counts: &[(CellId, usize)],
-    grid: &crate::spatial_structs::SquareGrid,
+    grid: &GridLayout,
     bbox: &Bbox,
 ) -> Option<(CellId, usize)> {
     let (columns, rows) = grid.intersect_bbox_ranges(bbox);
@@ -952,7 +1045,7 @@ impl CellCounts {
 
     fn merge_vertex_counts_with_bbox(
         vertex_counts: Vec<(CellId, usize)>,
-        grid: &crate::spatial_structs::SquareGrid,
+        grid: &GridLayout,
         bbox: &Bbox,
     ) -> Self {
         let (columns, rows) = grid.intersect_bbox_ranges(bbox);
@@ -1152,9 +1245,11 @@ mod tests {
     ) -> (CellId, usize) {
         let stats = selected_geometry_stats(model, Some(&vec![object_type]));
         let bbox = stats.bbox.unwrap();
-        let full_counts = count_vertices_in_grid(model, &stats.selected_vertices, grid, &bbox);
+        let layout = grid.layout();
+        let full_counts = count_vertices_in_grid(model, &stats.selected_vertices, &layout, &bbox);
         let expected = unique_assignment_winner_from_full_counts(&full_counts);
-        let optimized = count_unique_assignment_cell(model, &stats.selected_vertices, grid, &bbox);
+        let optimized =
+            count_unique_assignment_cell(model, &stats.selected_vertices, &layout, &bbox);
 
         assert_eq!(optimized, expected);
         optimized.expect("unique assignment should produce a winning cell")
@@ -1386,7 +1481,7 @@ mod tests {
         let counts = count_vertices_in_grid(
             &model,
             &stats.selected_vertices,
-            &grid,
+            &grid.layout(),
             &stats.bbox.unwrap(),
         );
 
@@ -1450,7 +1545,8 @@ mod tests {
             7415,
         );
 
-        let optimized = count_vertices_in_grid(&model, &stats.selected_vertices, &grid, &bbox);
+        let layout = grid.layout();
+        let optimized = count_vertices_in_grid(&model, &stats.selected_vertices, &layout, &bbox);
         let reference =
             reference_count_vertices_in_grid(&model, &stats.selected_vertices, &grid, &bbox);
 
@@ -1527,7 +1623,8 @@ mod tests {
             })
             .collect::<Vec<_>>();
 
-        let optimized = count_vertices_in_grid(&model, &selected_vertices, &grid, &bbox);
+        let layout = grid.layout();
+        let optimized = count_vertices_in_grid(&model, &selected_vertices, &layout, &bbox);
         let reference = reference_count_vertices_in_grid(&model, &selected_vertices, &grid, &bbox);
 
         assert_eq!(

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -265,8 +265,7 @@ impl World {
                     .iter_all_feature_ref_pages(CJINDEX_PAGE_SIZE)
                     .map_err(|e| std::io::Error::other(e.to_string()))?;
                 for page_result in pages_iter {
-                    let page =
-                        page_result.map_err(|e| std::io::Error::other(e.to_string()))?;
+                    let page = page_result.map_err(|e| std::io::Error::other(e.to_string()))?;
                     for chunk in page.chunks(CJINDEX_PARALLEL_CHUNK_SIZE) {
                         if chunk_tx.send(chunk.to_vec()).is_err() {
                             return Ok(());
@@ -376,10 +375,11 @@ impl World {
         let cityobject_types: Option<&Vec<CityObjectType>> = self.cityobject_types.as_ref();
         let grid_layout = grid.layout();
 
-        type ChunkResult = Result<Vec<Option<FeatureInGridCells>>, std::io::Error>;
         let (chunk_tx, chunk_rx) =
             std::sync::mpsc::sync_channel::<Vec<cityjson_index::IndexedFeatureRef>>(64);
-        let (result_tx, result_rx) = std::sync::mpsc::sync_channel::<ChunkResult>(64);
+        let (result_tx, result_rx) = std::sync::mpsc::sync_channel::<
+            Result<Vec<Option<FeatureInGridCells>>, std::io::Error>,
+        >(64);
 
         let mut indexed_features = 0usize;
         let mut consumer_err: Option<std::io::Error> = None;
@@ -393,62 +393,59 @@ impl World {
         //     in cells, and pushes the result to result_tx.
         //   Stage 3 (integrator, main thread): drains result_rx and applies the
         //     mutations to `features` and `grid`.
-        let loader_outcome = std::thread::scope(
-            |s| -> Result<(usize, usize), std::io::Error> {
-                let page_loader = s.spawn(move || -> Result<(usize, usize), std::io::Error> {
-                    let pages_iter = city_index
-                        .iter_all_feature_ref_pages(CJINDEX_PAGE_SIZE)
-                        .map_err(|e| std::io::Error::other(e.to_string()))?;
-                    let mut page_count = 0usize;
-                    let mut scanned_features = 0usize;
-                    for page_result in pages_iter {
-                        let page =
-                            page_result.map_err(|e| std::io::Error::other(e.to_string()))?;
-                        page_count += 1;
-                        scanned_features += page.len();
-                        for chunk in page.chunks(CJINDEX_PARALLEL_CHUNK_SIZE) {
-                            if chunk_tx.send(chunk.to_vec()).is_err() {
-                                return Ok((page_count, scanned_features));
-                            }
-                        }
-                    }
-                    Ok((page_count, scanned_features))
-                });
-
-                s.spawn(move || {
-                    chunk_rx
-                        .into_iter()
-                        .par_bridge()
-                        .for_each_with(result_tx, |tx, chunk| {
-                            let result = Self::index_cjindex_feature_refs_chunk(
-                                input_source,
-                                &grid_layout,
-                                cityobject_types,
-                                &chunk,
-                            );
-                            let _ = tx.send(result);
-                        });
-                });
-
-                while let Ok(result) = result_rx.recv() {
-                    match result {
-                        Ok(fics) => {
-                            for fic in fics.into_iter().flatten() {
-                                indexed_features += 1;
-                                integrate_feature_in_cells(features, grid, fic);
-                            }
-                        }
-                        Err(e) => {
-                            if consumer_err.is_none() {
-                                consumer_err = Some(e);
-                            }
+        let loader_outcome = std::thread::scope(|s| -> Result<(usize, usize), std::io::Error> {
+            let page_loader = s.spawn(move || -> Result<(usize, usize), std::io::Error> {
+                let pages_iter = city_index
+                    .iter_all_feature_ref_pages(CJINDEX_PAGE_SIZE)
+                    .map_err(|e| std::io::Error::other(e.to_string()))?;
+                let mut page_count = 0usize;
+                let mut scanned_features = 0usize;
+                for page_result in pages_iter {
+                    let page = page_result.map_err(|e| std::io::Error::other(e.to_string()))?;
+                    page_count += 1;
+                    scanned_features += page.len();
+                    for chunk in page.chunks(CJINDEX_PARALLEL_CHUNK_SIZE) {
+                        if chunk_tx.send(chunk.to_vec()).is_err() {
+                            return Ok((page_count, scanned_features));
                         }
                     }
                 }
+                Ok((page_count, scanned_features))
+            });
 
-                page_loader.join().expect("page loader thread panicked")
-            },
-        );
+            s.spawn(move || {
+                chunk_rx
+                    .into_iter()
+                    .par_bridge()
+                    .for_each_with(result_tx, |tx, chunk| {
+                        let result = Self::index_cjindex_feature_refs_chunk(
+                            input_source,
+                            &grid_layout,
+                            cityobject_types,
+                            &chunk,
+                        );
+                        let _ = tx.send(result);
+                    });
+            });
+
+            while let Ok(result) = result_rx.recv() {
+                match result {
+                    Ok(fics) => {
+                        for fic in fics.into_iter().flatten() {
+                            indexed_features += 1;
+                            integrate_feature_in_cells(features, grid, fic);
+                        }
+                    }
+                    Err(e) => {
+                        if consumer_err.is_none() {
+                            consumer_err = Some(e);
+                        }
+                    }
+                }
+            }
+
+            page_loader.join().expect("page loader thread panicked")
+        });
 
         if let Some(e) = consumer_err {
             return Err(Box::new(e));

--- a/src/spatial_structs.rs
+++ b/src/spatial_structs.rs
@@ -479,6 +479,60 @@ pub struct SquareGrid {
     pub epsg: u16,
 }
 
+/// Lightweight, copyable view of a [`SquareGrid`]'s metadata that exposes the
+/// read-only spatial queries (`locate_point`, `intersect_bbox_ranges`). Letting
+/// workers hold a `GridLayout` by value lets the integrator hold `&mut SquareGrid`
+/// concurrently without violating Rust's borrowing rules.
+#[derive(Debug, Clone, Copy)]
+pub struct GridLayout {
+    origin: [f64; 3],
+    pub bbox: Bbox,
+    pub length: usize,
+    cellsize: u32,
+    pub epsg: u16,
+}
+
+impl GridLayout {
+    pub fn locate_point(&self, point: &[f64; 2]) -> CellId {
+        let dx = point[0] - self.origin[0];
+        let dy = point[1] - self.origin[1];
+        let max_index = self.length.saturating_sub(1);
+        let col_i = ((dx / self.cellsize as f64).floor() as isize).clamp(0, max_index as isize);
+        let row_i = ((dy / self.cellsize as f64).floor() as isize).clamp(0, max_index as isize);
+        CellId {
+            row: row_i as usize,
+            column: col_i as usize,
+        }
+    }
+
+    pub fn intersect_bbox_ranges(
+        &self,
+        bbox: &Bbox,
+    ) -> (
+        std::ops::RangeInclusive<usize>,
+        std::ops::RangeInclusive<usize>,
+    ) {
+        let [minx, miny, _, maxx, maxy, _] = *bbox;
+        let min_cellid = self.locate_point(&[minx, miny]);
+        let max_cellid = self.locate_point(&[maxx, maxy]);
+        (
+            min_cellid.column..=max_cellid.column,
+            min_cellid.row..=max_cellid.row,
+        )
+    }
+
+    pub fn intersect_bbox(&self, bbox: &Bbox) -> Vec<CellId> {
+        let mut cellids: Vec<CellId> = Vec::new();
+        let (columns, rows) = self.intersect_bbox_ranges(bbox);
+        for column in columns {
+            for row in rows.clone() {
+                cellids.push(CellId { row, column });
+            }
+        }
+        cellids
+    }
+}
+
 impl Display for SquareGrid {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(
@@ -572,6 +626,19 @@ impl SquareGrid {
             cellsize,
             data: row,
             epsg,
+        }
+    }
+
+    /// A snapshot of the grid metadata needed for read-only spatial queries.
+    /// Pass this to worker threads instead of `&self` so the integrator can keep
+    /// exclusive access to the cell data.
+    pub fn layout(&self) -> GridLayout {
+        GridLayout {
+            origin: self.origin,
+            bbox: self.bbox,
+            length: self.length,
+            cellsize: self.cellsize,
+            epsg: self.epsg,
         }
     }
 


### PR DESCRIPTION
See ADR 010 for details. This cuts another ~8 min of the runtime of national 3DBAG dataset (~28m -> 20m, ex cjindex generation).