### PR TITLE
Fix GLB validation issues

### DIFF
--- a/cityjson-convert/src/gltf_writer.rs
+++ b/cityjson-convert/src/gltf_writer.rs
@@ -2251,6 +2251,7 @@ fn build_structural_metadata_columns(
     }
 
     let mut columns = BTreeMap::new();
+    let mut property_names = BTreeSet::new();
     for (name, kind) in column_types {
         let column = match kind {
             "bool" => build_bool_metadata_column(&name, features, buffer_builder),
@@ -2260,15 +2261,49 @@ fn build_structural_metadata_columns(
             "float" => {
                 build_float_metadata_column(&name, features, buffer_builder, meshopt_compression)?
             }
-            "string" => {
-                build_string_metadata_column(&name, features, buffer_builder, meshopt_compression)?
-            }
+            "string" => match build_string_metadata_column(
+                &name,
+                features,
+                buffer_builder,
+                meshopt_compression,
+            )? {
+                Some(column) => column,
+                None => continue,
+            },
             _ => continue,
         };
-        columns.insert(name, column);
+        columns.insert(metadata_property_name(&name, &mut property_names), column);
     }
 
     Ok(columns)
+}
+
+fn metadata_property_name(name: &str, used_names: &mut BTreeSet<String>) -> String {
+    let mut sanitized = String::new();
+    for (index, character) in name.chars().enumerate() {
+        if character == '_' || character.is_ascii_alphanumeric() {
+            if index == 0 && character.is_ascii_digit() {
+                sanitized.push('_');
+            }
+            sanitized.push(character);
+        } else {
+            sanitized.push('_');
+        }
+    }
+
+    if sanitized.is_empty() {
+        sanitized.push('_');
+    }
+
+    let base = sanitized;
+    let mut candidate = base.clone();
+    let mut suffix = 1usize;
+    while used_names.contains(&candidate) {
+        candidate = format!("{base}_{suffix}");
+        suffix += 1;
+    }
+    used_names.insert(candidate.clone());
+    candidate
 }
 
 fn build_bool_metadata_column(
@@ -2359,7 +2394,7 @@ fn build_string_metadata_column(
     features: &[FeatureRecord],
     buffer_builder: &mut BufferBuilder,
     meshopt_compression: bool,
-) -> Result<StructuralMetadataColumn> {
+) -> Result<Option<StructuralMetadataColumn>> {
     let mut values = Vec::<u8>::new();
     let mut offsets = Vec::<u32>::with_capacity(features.len() + 1);
     offsets.push(0);
@@ -2370,11 +2405,15 @@ fn build_string_metadata_column(
         offsets.push(u32::try_from(values.len()).expect("string column offset within u32 range"));
     }
 
+    if values.is_empty() {
+        return Ok(None);
+    }
+
     let values_view =
         buffer_builder.push_byte_buffer_view(&values, json::buffer::Target::ArrayBuffer);
     let offsets_view =
         buffer_builder.push_metadata_scalar_buffer_view(&offsets, meshopt_compression)?;
-    Ok(StructuralMetadataColumn {
+    Ok(Some(StructuralMetadataColumn {
         property: json_value!({
             "type": "STRING",
         }),
@@ -2383,7 +2422,7 @@ fn build_string_metadata_column(
             "stringOffsets": offsets_view.value(),
             "stringOffsetType": "UINT32",
         }),
-    })
+    }))
 }
 
 impl StructuralMetadataExtension {

--- a/cityjson-convert/tests/gltf_writer_geometry.rs
+++ b/cityjson-convert/tests/gltf_writer_geometry.rs
@@ -362,6 +362,105 @@ fn convert_to_glb_omits_metadata_table_when_features_have_no_attributes() {
 }
 
 #[test]
+fn convert_to_glb_omits_empty_string_metadata_columns() {
+    let model = json::from_slice(
+        br#"{
+            "type":"CityJSON",
+            "version":"2.0",
+            "CityObjects":{
+                "building-1":{
+                    "type":"Building",
+                    "attributes":{"name":""},
+                    "geometry":[{
+                        "type":"MultiSurface",
+                        "lod":"2.2",
+                        "boundaries":[[[0,1,2]]]
+                    }]
+                }
+            },
+            "vertices":[
+                [0.0,0.0,0.0],
+                [1.0,0.0,0.0],
+                [0.0,1.0,0.0]
+            ]
+        }"#,
+    )
+    .expect("inline CityJSON fixture should parse");
+    let output_path = stable_output_path("empty-string-metadata");
+
+    convert_to_glb(&model, &output_path, &ExportOptions::default())
+        .expect("GLB conversion should succeed with empty string metadata");
+
+    let glb_bytes = fs::read(&output_path).expect("test GLB should be written");
+    let root = read_glb_json(&glb_bytes);
+
+    assert!(!has_extension(&root, "EXT_structural_metadata"));
+
+    let buffer_views = root["bufferViews"]
+        .as_array()
+        .expect("glTF should contain bufferViews");
+    for (index, buffer_view) in buffer_views.iter().enumerate() {
+        assert!(
+            buffer_view["byteLength"].as_u64().unwrap() > 0,
+            "bufferView {index} should not have zero byteLength"
+        );
+    }
+}
+
+#[test]
+fn convert_to_glb_sanitizes_structural_metadata_property_names() {
+    let model = json::from_slice(
+        br#"{
+            "type":"CityJSON",
+            "version":"2.0",
+            "CityObjects":{
+                "building-1":{
+                    "type":"Building",
+                    "attributes":{
+                        "3df_id":"building-1",
+                        "3df_class":"Building"
+                    },
+                    "geometry":[{
+                        "type":"MultiSurface",
+                        "lod":"2.2",
+                        "boundaries":[[[0,1,2]]]
+                    }]
+                }
+            },
+            "vertices":[
+                [0.0,0.0,0.0],
+                [1.0,0.0,0.0],
+                [0.0,1.0,0.0]
+            ]
+        }"#,
+    )
+    .expect("inline CityJSON fixture should parse");
+    let output_path = stable_output_path("sanitized-metadata-properties");
+
+    convert_to_glb(&model, &output_path, &ExportOptions::default())
+        .expect("GLB conversion should succeed with numeric-leading metadata names");
+
+    let glb_bytes = fs::read(&output_path).expect("test GLB should be written");
+    let root = read_glb_json(&glb_bytes);
+    let properties = root["extensions"]["EXT_structural_metadata"]["schema"]["classes"]
+        ["cityobject"]["properties"]
+        .as_object()
+        .expect("metadata schema should contain sanitized properties");
+
+    assert!(properties.contains_key("_3df_id"));
+    assert!(properties.contains_key("_3df_class"));
+    assert!(!properties.contains_key("3df_id"));
+    assert!(!properties.contains_key("3df_class"));
+
+    let table_properties = root["extensions"]["EXT_structural_metadata"]["propertyTables"][0]
+        ["properties"]
+        .as_object()
+        .expect("property table should use the same sanitized names");
+    assert!(table_properties.contains_key("_3df_id"));
+    assert!(table_properties.contains_key("_3df_class"));
+}
+
+#[test]
 fn convert_to_glb_can_reproject_geometry_to_ecef() {
     let model = json::merge_feature_stream_slice(include_bytes!("data/ams_up_holes.city.jsonl"))
         .expect("fixture feature stream should parse");


### PR DESCRIPTION
Implemented two GLB validation fixes in cityjson-convert/src/gltf_writer.rs:

- Omitted all-empty string metadata columns so the writer no longer emits bufferViews with byteLength: 0.
- Sanitized structural metadata property names so CityJSON attributes like 3df_id and 3df_class become valid glTF metadata identifiers like _3df_id and _3df_class.

Added regression tests for both cases in cityjson-convert/tests/gltf_writer_geometry.rs.

This fixes #94. Ran against https://github.com/CesiumGS/3d-tiles-validator.