### PR TITLE
Rework CityObject filtering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,9 +15,10 @@
 # Test data
 /tests/output*
 /cityjson-convert/tests/output/
-.geodepot
+.geodepot.bak
 
 # Debug data
 *.tsv
 *.bincode
 *.log
+/docs/plans/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,13 @@
 - `--include-parent-attributes` now copies inherited parent attributes even when the parent object type itself is not selected.
 - `--3dtiles-metadata-class` now defaults to `citymodel`.
 - When no `--lod-*` override is supplied, Tyler now keeps the highest available LoD per CityObject by default.
+- CityObject type and LoD filtering now run once through the shared `cjindex` filtering path before extent, grid, tile, and export decisions, so tile bounds and output content use the same retained geometry.
 - README, Dockerfiles, Nix, and bundled resources were updated for the new pipeline.
+
+### Fixed
+
+- Missing explicit `--lod-*` selections now fail before tile export with diagnostics for available LoDs instead of producing empty tile models late in the pipeline.
+- `--object-type Building` filtering now keeps descendant geometry such as `BuildingPart` objects when those children are part of the selected building hierarchy.
 
 ## tyler 0.3.14 (2025-10-22)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -289,7 +289,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 [[package]]
 name = "cityjson"
 version = "0.8.0"
-source = "git+https://github.com/3DGI/cityjson?branch=main#4aa8d60d94170be65aea6abaae52df120f9ff2a3"
+source = "git+https://github.com/3DGI/cityjson?branch=main#ec724d3c3755552a5db8557cdc0025db6cb8c25d"
 dependencies = [
  "num 0.4.3",
 ]
@@ -316,7 +316,7 @@ dependencies = [
 [[package]]
 name = "cityjson-index"
 version = "0.8.0"
-source = "git+https://github.com/3DGI/cityjson?branch=main#4aa8d60d94170be65aea6abaae52df120f9ff2a3"
+source = "git+https://github.com/3DGI/cityjson?branch=main#ec724d3c3755552a5db8557cdc0025db6cb8c25d"
 dependencies = [
  "cityjson-lib",
  "clap",
@@ -337,7 +337,7 @@ dependencies = [
 [[package]]
 name = "cityjson-json"
 version = "0.8.0"
-source = "git+https://github.com/3DGI/cityjson?branch=main#4aa8d60d94170be65aea6abaae52df120f9ff2a3"
+source = "git+https://github.com/3DGI/cityjson?branch=main#ec724d3c3755552a5db8557cdc0025db6cb8c25d"
 dependencies = [
  "ahash",
  "cityjson",
@@ -349,7 +349,7 @@ dependencies = [
 [[package]]
 name = "cityjson-lib"
 version = "0.8.0"
-source = "git+https://github.com/3DGI/cityjson?branch=main#4aa8d60d94170be65aea6abaae52df120f9ff2a3"
+source = "git+https://github.com/3DGI/cityjson?branch=main#ec724d3c3755552a5db8557cdc0025db6cb8c25d"
 dependencies = [
  "cityjson",
  "cityjson-json",

--- a/src/formats.rs
+++ b/src/formats.rs
@@ -56,6 +56,17 @@ pub mod cesium3dtiles {
     }
 
     impl Tileset {
+        fn normalize_tileset_geometric_error(
+            root: &Tile,
+            geometric_error: GeometricError,
+        ) -> GeometricError {
+            if root.children.is_none() {
+                geometric_error.max(f64::EPSILON)
+            } else {
+                geometric_error
+            }
+        }
+
         /// Write the tileset to a `tileset.json` file
         pub fn to_file<P: AsRef<Path>>(&self, path: P) -> Result<(), Box<dyn std::error::Error>> {
             let file_out = File::create(path.as_ref())?;
@@ -165,6 +176,10 @@ pub mod cesium3dtiles {
         ) -> Self {
             let crs_from = format!("EPSG:{}", world.crs.to_epsg().unwrap());
             let transformer = Proj::new_known_crs(&crs_from, "EPSG:4979", None).unwrap();
+            let root_bbox = quadtree.bbox(&world.grid);
+            let root_geometric_error = ((root_bbox[3] - root_bbox[0])
+                .max(root_bbox[4] - root_bbox[1]))
+                * geometric_error_factor;
 
             let root = Self::generate_tiles(
                 quadtree,
@@ -201,10 +216,12 @@ pub mod cesium3dtiles {
             // Apply root transform to root tile
             let mut root_with_transform = root;
             root_with_transform.transform = Some(root_transform);
+            let geometric_error =
+                Self::normalize_tileset_geometric_error(&root_with_transform, root_geometric_error);
 
             Self {
                 asset: Default::default(),
-                geometric_error: root_with_transform.geometric_error,
+                geometric_error,
                 root: root_with_transform,
                 properties: None,
                 extensions_used: Some(vec![ExtensionName::ContentGltf]),
@@ -1072,12 +1089,15 @@ pub mod cesium3dtiles {
                     let filename =
                         format!("tileset-{}-{}-{}.json", tile.id.level, tile.id.x, tile.id.y);
                     // Create the new tileset
+                    let root = tile.clone();
+                    let geometric_error =
+                        Self::normalize_tileset_geometric_error(&root, root.geometric_error);
                     child_tilesets.push((
                         filename.clone(),
                         Tileset {
                             asset: Default::default(),
-                            geometric_error: tile.geometric_error,
-                            root: tile.clone(),
+                            geometric_error,
+                            root,
                             properties: None,
                             extensions_used: None,
                             extensions_required: None,
@@ -1925,7 +1945,14 @@ pub mod cesium3dtiles {
             );
             assert_tile_bounding_volumes_are_regions(&tileset.root);
             assert_geometric_error_decreases_to_zero(&tileset.root);
-            assert!((tileset.geometric_error - tileset.root.geometric_error).abs() <= f64::EPSILON);
+            if tileset.root.children.is_some() {
+                assert!(
+                    (tileset.geometric_error - tileset.root.geometric_error).abs() <= f64::EPSILON
+                );
+            } else {
+                assert!(tileset.root.geometric_error.abs() <= f64::EPSILON);
+                assert!(tileset.geometric_error > f64::EPSILON);
+            }
             let root_transform = tileset
                 .root
                 .transform

--- a/src/formats.rs
+++ b/src/formats.rs
@@ -1879,15 +1879,21 @@ pub mod cesium3dtiles {
             let metadata_path = dataset_dir.join("metadata.city.json");
             fs::write(&metadata_path, &feature_base_document).expect("write metadata");
 
+            let cityobject_types = Some(vec![
+                crate::parser::CityObjectType::Building,
+                crate::parser::CityObjectType::BuildingPart,
+            ]);
+            let feature_filter = crate::build_feature_filter(
+                cityobject_types.as_ref(),
+                &std::collections::BTreeMap::new(),
+            );
             let mut world = crate::parser::World::from_cjindex(
                 crate::parser::InputSource::from_cjindex_resolved(&resolved),
                 metadata_path,
                 feature_base_document,
                 200,
-                Some(vec![
-                    crate::parser::CityObjectType::Building,
-                    crate::parser::CityObjectType::BuildingPart,
-                ]),
+                cityobject_types,
+                feature_filter,
                 None,
                 None,
             )

--- a/src/main.rs
+++ b/src/main.rs
@@ -834,7 +834,6 @@ fn prepare_feature_model(
     cleanup_feature: bool,
 ) -> Result<Option<cityjson_lib::CityModel>, Box<dyn std::error::Error>> {
     let mut model = model;
-    let prepare_started = Instant::now();
     let lods_pruned = prune_lod_geometries(&mut model, feature_type_lods)?;
     if include_parent_attributes {
         inherit_parent_attributes(&mut model)?;
@@ -869,23 +868,9 @@ fn prepare_feature_model(
         return Ok(None);
     }
     if cleanup_feature {
-        let cleanup_started = Instant::now();
         let cleaned = cleanup_and_update_extents(model)?;
-        debug!(
-            "Cleaned debug tile feature {} in {:?} (total prepare {:?})",
-            feature_id,
-            cleanup_started.elapsed(),
-            prepare_started.elapsed()
-        );
         Ok(Some(cleaned))
     } else {
-        debug!(
-            "Prepared tile feature {} in {:?} (type_filter={}, remove_empty={}, cleanup=false)",
-            feature_id,
-            prepare_started.elapsed(),
-            needs_type_filter,
-            remove_empty_geometry
-        );
         Ok(Some(model))
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,7 +64,7 @@ mod parser;
 mod proj;
 mod spatial_structs;
 
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::fs;
 use std::fs::File;
 use std::io::Write;
@@ -74,7 +74,7 @@ use std::time::Instant;
 use crate::coordinates::RootEnuFrame;
 use crate::formats::cesium3dtiles::{Tile, TileId};
 use crate::proj::Proj;
-use cityjson_lib::cityjson::prelude::{CityObjectHandle, GeometryHandle};
+use cityjson_lib::cityjson::prelude::CityObjectHandle;
 use clap::Parser;
 use log::{debug, info, log_enabled, warn, Level};
 use rayon::prelude::*;
@@ -230,6 +230,30 @@ fn build_feature_type_lods(cli: &crate::cli::Cli) -> BTreeMap<String, String> {
     }
 
     feature_type_lods
+}
+
+fn build_feature_filter(
+    cityobject_types: Option<&Vec<parser::CityObjectType>>,
+    feature_type_lods: &BTreeMap<String, String>,
+) -> cityjson_index::FeatureFilter {
+    cityjson_index::FeatureFilter {
+        cityobject_types: cityobject_types.map(|types| {
+            types
+                .iter()
+                .map(std::string::ToString::to_string)
+                .collect::<BTreeSet<_>>()
+        }),
+        default_lod: cityjson_index::LodSelection::Highest,
+        lods_by_type: feature_type_lods
+            .iter()
+            .map(|(feature_type, lod)| {
+                (
+                    feature_type.clone(),
+                    cityjson_index::LodSelection::Exact(lod.clone()),
+                )
+            })
+            .collect(),
+    }
 }
 
 fn build_object_attribute_types(
@@ -720,7 +744,6 @@ fn feature_reference_precedes(
 fn build_tile_model_from_feature_ids(
     world: &parser::World,
     feature_ids: &[usize],
-    feature_type_lods: &BTreeMap<String, String>,
     object_attribute_types: &BTreeMap<String, ObjectAttributeType>,
     include_parent_attributes: bool,
 ) -> Result<cityjson_lib::CityModel, Box<dyn std::error::Error>> {
@@ -728,7 +751,6 @@ fn build_tile_model_from_feature_ids(
     let models = prepare_tile_feature_models(
         world,
         &deduplicated_feature_ids,
-        feature_type_lods,
         object_attribute_types,
         include_parent_attributes,
         false,
@@ -753,19 +775,12 @@ fn build_tile_model(
     qtree_node: &spatial_structs::QuadTree,
 ) -> Result<cityjson_lib::CityModel, Box<dyn std::error::Error>> {
     let feature_ids = collect_tile_feature_ids(world, qtree_node);
-    build_tile_model_from_feature_ids(
-        world,
-        &feature_ids,
-        &BTreeMap::new(),
-        &BTreeMap::new(),
-        false,
-    )
+    build_tile_model_from_feature_ids(world, &feature_ids, &BTreeMap::new(), false)
 }
 
 fn build_tile_debug_cityjsonseq(
     world: &parser::World,
     feature_ids: &[usize],
-    feature_type_lods: &BTreeMap<String, String>,
     object_attribute_types: &BTreeMap<String, ObjectAttributeType>,
     include_parent_attributes: bool,
 ) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
@@ -773,7 +788,6 @@ fn build_tile_debug_cityjsonseq(
     let models = prepare_tile_feature_models(
         world,
         &deduplicated_feature_ids,
-        feature_type_lods,
         object_attribute_types,
         include_parent_attributes,
         true,
@@ -792,7 +806,6 @@ fn build_tile_debug_cityjsonseq(
 fn prepare_tile_feature_models(
     world: &parser::World,
     feature_ids: &[usize],
-    feature_type_lods: &BTreeMap<String, String>,
     object_attribute_types: &BTreeMap<String, ObjectAttributeType>,
     include_parent_attributes: bool,
     cleanup_features: bool,
@@ -806,11 +819,7 @@ fn prepare_tile_feature_models(
                 model,
                 feature_id,
                 world.cityobject_types.as_ref(),
-                world
-                    .cityobject_types
-                    .as_ref()
-                    .is_some_and(|_| world.features[feature_id].needs_type_filter),
-                feature_type_lods,
+                &world.feature_filter,
                 object_attribute_types,
                 include_parent_attributes,
                 cleanup_features,
@@ -825,40 +834,24 @@ fn prepare_tile_feature_models(
 
 fn prepare_feature_model(
     model: cityjson_lib::CityModel,
-    feature_id: usize,
-    cityobject_types: Option<&Vec<parser::CityObjectType>>,
-    needs_type_filter: bool,
-    feature_type_lods: &BTreeMap<String, String>,
+    _feature_id: usize,
+    _cityobject_types: Option<&Vec<parser::CityObjectType>>,
+    feature_filter: &cityjson_index::FeatureFilter,
     object_attribute_types: &BTreeMap<String, ObjectAttributeType>,
     include_parent_attributes: bool,
     cleanup_feature: bool,
 ) -> Result<Option<cityjson_lib::CityModel>, Box<dyn std::error::Error>> {
     let mut model = model;
-    let lods_pruned = prune_lod_geometries(&mut model, feature_type_lods)?;
     if include_parent_attributes {
         inherit_parent_attributes(&mut model)?;
     }
     if !object_attribute_types.is_empty() {
         apply_object_attribute_types(&mut model, object_attribute_types)?;
     }
-    let type_filter_started = Instant::now();
-    let model = if needs_type_filter {
-        filter_cityobject_types(model, cityobject_types)?
-    } else {
-        model
-    };
-    if needs_type_filter {
-        debug!(
-            "Filtered feature {} cityobject types in {:?}",
-            feature_id,
-            type_filter_started.elapsed()
-        );
-    }
-    let remove_empty_geometry = cleanup_feature
-        || lods_pruned
-        || include_parent_attributes
-        || needs_type_filter
-        || !object_attribute_types.is_empty();
+    let filtered = feature_filter.apply(&model)?;
+    model = filtered.model;
+    let remove_empty_geometry =
+        cleanup_feature || include_parent_attributes || !object_attribute_types.is_empty();
     let model = if remove_empty_geometry {
         remove_empty_geometry_cityobjects(&model)?
     } else {
@@ -1018,6 +1011,38 @@ where
     Ok(filtered)
 }
 
+#[cfg(test)]
+pub(crate) fn filter_cityjsonfeature_preserving_root_with_policy(
+    model: &cityjson_lib::CityModel,
+    cityobject_types: Option<&Vec<parser::CityObjectType>>,
+    feature_type_lods: &BTreeMap<String, String>,
+    default_highest_lod: bool,
+) -> Result<cityjson_lib::CityModel, Box<dyn std::error::Error>> {
+    let filter = cityjson_index::FeatureFilter {
+        cityobject_types: cityobject_types.map(|types| {
+            types
+                .iter()
+                .map(std::string::ToString::to_string)
+                .collect::<BTreeSet<_>>()
+        }),
+        default_lod: if default_highest_lod {
+            cityjson_index::LodSelection::Highest
+        } else {
+            cityjson_index::LodSelection::All
+        },
+        lods_by_type: feature_type_lods
+            .iter()
+            .map(|(feature_type, lod)| {
+                (
+                    feature_type.clone(),
+                    cityjson_index::LodSelection::Exact(lod.clone()),
+                )
+            })
+            .collect(),
+    };
+    Ok(filter.apply(model)?.model)
+}
+
 fn parentless_cityobject_handle(model: &cityjson_lib::CityModel) -> Option<CityObjectHandle> {
     model.cityobjects().iter().find_map(|(handle, cityobject)| {
         let has_surviving_parent = cityobject.parents().is_some_and(|parents| {
@@ -1029,20 +1054,17 @@ fn parentless_cityobject_handle(model: &cityjson_lib::CityModel) -> Option<CityO
     })
 }
 
+#[cfg(test)]
 fn filter_cityobject_types(
     model: cityjson_lib::CityModel,
     cityobject_types: Option<&Vec<parser::CityObjectType>>,
 ) -> Result<cityjson_lib::CityModel, Box<dyn std::error::Error>> {
-    let Some(cityobject_types) = cityobject_types else {
-        return Ok(model);
-    };
-    let selected = cityobject_types
-        .iter()
-        .map(std::string::ToString::to_string)
-        .collect::<HashSet<_>>();
-    filter_cityjsonfeature_preserving_root(&model, |ctx| {
-        selected.contains(&ctx.cityobject().type_cityobject().to_string())
-    })
+    filter_cityjsonfeature_preserving_root_with_policy(
+        &model,
+        cityobject_types,
+        &BTreeMap::new(),
+        false,
+    )
 }
 
 fn apply_object_attribute_types(
@@ -1143,92 +1165,17 @@ fn parse_bool_attribute(value: &str) -> Option<bool> {
     }
 }
 
+#[cfg(test)]
 fn prune_lod_geometries(
     model: &mut cityjson_lib::CityModel,
     feature_type_lods: &BTreeMap<String, String>,
 ) -> Result<bool, Box<dyn std::error::Error>> {
-    let retained_by_object = model
-        .cityobjects()
-        .iter()
-        .map(|(handle, cityobject)| {
-            let feature_type = cityobject.type_cityobject().to_string();
-            let selected_lod = feature_type_lods.get(&feature_type);
-            let retained = selected_geometry_handles_for_lod(
-                model,
-                cityobject.geometry().unwrap_or(&[]),
-                selected_lod,
-            );
-            (handle, retained)
-        })
-        .collect::<Vec<_>>();
-
-    let mut changed = false;
-    for (handle, retained) in retained_by_object {
-        let cityobject = model
-            .cityobjects_mut()
-            .get_mut(handle)
-            .ok_or_else(|| format!("missing CityObject handle {handle} during LoD pruning"))?;
-        let original = cityobject.geometry().unwrap_or(&[]).to_vec();
-        if original != retained {
-            changed = true;
-        }
-        cityobject.clear_geometry();
-        for geometry_handle in retained {
-            cityobject.add_geometry(geometry_handle);
-        }
-    }
-
+    let filtered =
+        filter_cityjsonfeature_preserving_root_with_policy(model, None, feature_type_lods, true)?;
+    let changed = filtered.geometry_count() != model.geometry_count()
+        || filtered.cityobjects().len() != model.cityobjects().len();
+    *model = filtered;
     Ok(changed)
-}
-
-fn selected_geometry_handles_for_lod(
-    model: &cityjson_lib::CityModel,
-    geometries: &[GeometryHandle],
-    selected_lod: Option<&String>,
-) -> Vec<GeometryHandle> {
-    let Some(selected_lod) = selected_lod
-        .cloned()
-        .or_else(|| highest_lod(model, geometries))
-    else {
-        return geometries.to_vec();
-    };
-    geometries
-        .iter()
-        .copied()
-        .filter(|geometry_handle| {
-            geometry_matches_lod(model, *geometry_handle, selected_lod.as_str())
-        })
-        .collect()
-}
-
-fn highest_lod(model: &cityjson_lib::CityModel, geometries: &[GeometryHandle]) -> Option<String> {
-    geometries
-        .iter()
-        .filter_map(|geometry_handle| {
-            model
-                .get_geometry(*geometry_handle)
-                .and_then(|geometry| geometry.lod())
-                .map(std::string::ToString::to_string)
-        })
-        .max_by(|lhs, rhs| compare_lod_strings(lhs, rhs))
-}
-
-fn compare_lod_strings(lhs: &str, rhs: &str) -> std::cmp::Ordering {
-    match (lhs.parse::<f64>(), rhs.parse::<f64>()) {
-        (Ok(lhs), Ok(rhs)) => lhs.total_cmp(&rhs),
-        _ => lhs.cmp(rhs),
-    }
-}
-
-fn geometry_matches_lod(
-    model: &cityjson_lib::CityModel,
-    geometry_handle: GeometryHandle,
-    selected_lod: &str,
-) -> bool {
-    model
-        .get_geometry(geometry_handle)
-        .and_then(|geometry| geometry.lod())
-        .is_some_and(|lod| lod.to_string() == selected_lod)
 }
 
 fn remove_empty_geometry_cityobjects(
@@ -1350,6 +1297,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         None
     };
     let cityobject_types = cli.object_type.clone();
+    let feature_type_lods = build_feature_type_lods(&cli);
+    let feature_filter = build_feature_filter(cityobject_types.as_ref(), &feature_type_lods);
 
     let world: parser::World = match debug_data.world {
         None => {
@@ -1362,6 +1311,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 prepared_input.feature_base_document.clone(),
                 grid_cellsize,
                 cityobject_types,
+                feature_filter,
                 cli.grid_minz,
                 cli.grid_maxz,
             )?;
@@ -1541,7 +1491,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             up: root_enu_frame.up,
         };
         let export_options = build_glb_export_options(&cli, geometry_placement, None);
-        let feature_type_lods = build_feature_type_lods(&cli);
         let object_attribute_types = object_attribute_types.clone();
         let tiles_len = export_jobs.len();
         let all_content_tile_ids: Vec<TileId> = export_jobs
@@ -1564,7 +1513,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             let model = match build_tile_model_from_feature_ids(
                 &world,
                 &job.feature_ids,
-                &feature_type_lods,
                 &object_attribute_types,
                 cli.include_parent_attributes,
             ) {
@@ -1581,7 +1529,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 let cityjsonseq_bytes = match build_tile_debug_cityjsonseq(
                     &world,
                     &job.feature_ids,
-                    &feature_type_lods,
                     &object_attribute_types,
                     cli.include_parent_attributes,
                 ) {
@@ -2087,12 +2034,16 @@ mod tests {
         include_parent_attributes: bool,
     ) -> cityjson_lib::CityModel {
         let mut model = model;
-        prune_lod_geometries(&mut model, &BTreeMap::new()).expect("LoD pruning should succeed");
         if include_parent_attributes {
             inherit_parent_attributes(&mut model).expect("attribute inheritance should succeed");
         }
-        let model = filter_cityobject_types(model, Some(&cityobject_types))
-            .expect("type filter should succeed");
+        let model = filter_cityjsonfeature_preserving_root_with_policy(
+            &model,
+            Some(&cityobject_types),
+            &BTreeMap::new(),
+            true,
+        )
+        .expect("type filter should succeed");
         let model =
             remove_empty_geometry_cityobjects(&model).expect("empty object removal should succeed");
         cleanup_and_update_extents(model).expect("cleanup should succeed")
@@ -2100,15 +2051,31 @@ mod tests {
 
     #[test]
     fn prepare_feature_model_skips_empty_geometry_removal_for_gltf_noop_path() {
-        let model = parent_attribute_remapping_fixture(serde_json::json!({}));
+        let model = cityjson_lib::json::from_feature_slice(
+            br#"{
+                "type":"CityJSONFeature",
+                "id":"building-part",
+                "CityObjects":{
+                    "building-part":{
+                        "type":"BuildingPart",
+                        "geometry":[{
+                            "type":"MultiSurface",
+                            "lod":"1",
+                            "boundaries":[[[0,1,2]]]
+                        }]
+                    }
+                },
+                "vertices":[[0,0,0],[1,0,0],[0,1,0]]
+            }"#,
+        )
+        .expect("simple model should parse");
         let original_signature = geometry_relevant_signature(&model);
 
         let prepared = prepare_feature_model(
             model.clone(),
             0,
             None,
-            false,
-            &BTreeMap::new(),
+            &cityjson_index::FeatureFilter::default(),
             &BTreeMap::new(),
             false,
             false,
@@ -2145,13 +2112,13 @@ mod tests {
         )
         .expect("building-part fixture should parse");
         let selected_types = vec![parser::CityObjectType::BuildingPart];
+        let feature_filter = build_feature_filter(Some(&selected_types), &BTreeMap::new());
 
         let skipped = prepare_feature_model(
             model.clone(),
             0,
             Some(&selected_types),
-            false,
-            &BTreeMap::new(),
+            &feature_filter,
             &BTreeMap::new(),
             false,
             false,
@@ -2162,8 +2129,7 @@ mod tests {
             model,
             0,
             Some(&selected_types),
-            true,
-            &BTreeMap::new(),
+            &feature_filter,
             &BTreeMap::new(),
             false,
             false,
@@ -2238,6 +2204,159 @@ mod tests {
             .collect::<Vec<_>>();
         duplicate_types.sort();
         assert_eq!(duplicate_types, vec!["Building"]);
+    }
+
+    #[test]
+    fn build_feature_filter_maps_cli_types_lods_and_default_highest_policy() {
+        let cityobject_types = vec![
+            parser::CityObjectType::Building,
+            parser::CityObjectType::BuildingPart,
+        ];
+        let lods = BTreeMap::from([
+            ("Building".to_string(), "2.0".to_string()),
+            ("BuildingPart".to_string(), "1.3".to_string()),
+        ]);
+
+        let filter = build_feature_filter(Some(&cityobject_types), &lods);
+
+        assert_eq!(
+            filter.cityobject_types,
+            Some(BTreeSet::from([
+                "Building".to_string(),
+                "BuildingPart".to_string(),
+            ]))
+        );
+        assert_eq!(filter.default_lod, cityjson_index::LodSelection::Highest);
+        assert_eq!(
+            filter.lods_by_type.get("Building"),
+            Some(&cityjson_index::LodSelection::Exact("2.0".to_string()))
+        );
+        assert_eq!(
+            filter.lods_by_type.get("BuildingPart"),
+            Some(&cityjson_index::LodSelection::Exact("1.3".to_string()))
+        );
+    }
+
+    #[test]
+    fn shared_filter_object_type_only_keeps_all_geometries_for_selected_types() {
+        let model = multi_type_lod_fixture();
+        let filtered = filter_cityjsonfeature_preserving_root_with_policy(
+            &model,
+            Some(&vec![parser::CityObjectType::BuildingPart]),
+            &BTreeMap::new(),
+            false,
+        )
+        .expect("type-only filtering should succeed");
+
+        let retained = retained_lods_by_object_id(&filtered);
+        assert_eq!(
+            retained.get("building-part"),
+            Some(&vec!["1".to_string(), "3".to_string()])
+        );
+        assert!(!retained.contains_key("building"));
+    }
+
+    #[test]
+    fn shared_filter_defaults_to_highest_lod_for_every_cityobject() {
+        let model = multi_type_lod_fixture();
+        let filtered = filter_cityjsonfeature_preserving_root_with_policy(
+            &model,
+            None,
+            &BTreeMap::new(),
+            true,
+        )
+        .expect("default highest filtering should succeed");
+
+        let retained = retained_lods_by_object_id(&filtered);
+        assert_eq!(retained.get("building"), Some(&vec!["2".to_string()]));
+        assert_eq!(retained.get("building-part"), Some(&vec!["3".to_string()]));
+    }
+
+    #[test]
+    fn world_extent_uses_highest_lod_geometry_for_selected_types() {
+        let dataset_dir = unique_test_dir("highest-lod-extent");
+        let feature_base_document =
+            fs::read(resource_path("3dbag_x00.city.json")).expect("read metadata");
+        let metadata_path = dataset_dir.join("metadata.json");
+        fs::write(&metadata_path, &feature_base_document).expect("write metadata");
+        let feature_path = dataset_dir.join("source.city.jsonl");
+        fs::write(
+            &feature_path,
+            serde_json::json!({
+                "type": "CityJSONFeature",
+                "id": "lod-extent",
+                "CityObjects": {
+                    "lod-extent": {
+                        "type": "BuildingPart",
+                        "geometry": [
+                            {
+                                "type": "MultiSurface",
+                                "lod": "1.0",
+                                "boundaries": [[[0, 1, 2]]]
+                            },
+                            {
+                                "type": "MultiSurface",
+                                "lod": "2.0",
+                                "boundaries": [[[3, 4, 5]]]
+                            }
+                        ]
+                    }
+                },
+                "vertices": [
+                    [0, 0, 0],
+                    [1, 0, 0],
+                    [0, 1, 0],
+                    [10, 10, 0],
+                    [11, 10, 0],
+                    [10, 11, 0]
+                ]
+            })
+            .to_string(),
+        )
+        .expect("write highest-lod extent feature");
+
+        let resolved = cityjson_index::resolve_dataset(&dataset_dir, None)
+            .expect("resolve highest-lod extent dataset");
+        let mut city_index =
+            cityjson_index::CityIndex::open(resolved.storage_layout(), &resolved.index_path)
+                .expect("open index");
+        city_index.reindex().expect("reindex extent dataset");
+        let feature_base_document =
+            derive_base_document(&city_index).expect("derive base doc for extent dataset");
+        fs::write(&metadata_path, &feature_base_document).expect("write metadata");
+
+        let low_types = Some(vec![parser::CityObjectType::BuildingPart]);
+        let low_lods = BTreeMap::from([("BuildingPart".to_string(), "1.0".to_string())]);
+        let low_filter = build_feature_filter(low_types.as_ref(), &low_lods);
+        let world_low = parser::World::from_cjindex(
+            parser::InputSource::from_cjindex_resolved(&resolved),
+            metadata_path.clone(),
+            feature_base_document.clone(),
+            200,
+            low_types,
+            low_filter,
+            None,
+            None,
+        )
+        .expect("build low-lod cjindex world");
+
+        let high_types = Some(vec![parser::CityObjectType::BuildingPart]);
+        let high_lods = BTreeMap::from([("BuildingPart".to_string(), "2.0".to_string())]);
+        let high_filter = build_feature_filter(high_types.as_ref(), &high_lods);
+        let world_high = parser::World::from_cjindex(
+            parser::InputSource::from_cjindex_resolved(&resolved),
+            metadata_path,
+            feature_base_document,
+            200,
+            high_types,
+            high_filter,
+            None,
+            None,
+        )
+        .expect("build high-lod cjindex world");
+
+        assert!(world_low.grid.bbox[0] < world_high.grid.bbox[0]);
+        assert!(world_low.grid.bbox[3] < world_high.grid.bbox[3]);
     }
 
     #[test]
@@ -2580,15 +2699,18 @@ mod tests {
         let metadata_path = dataset_dir.join("metadata.city.json");
         fs::write(&metadata_path, &feature_base_document).expect("write metadata");
 
+        let cityobject_types = Some(vec![
+            parser::CityObjectType::Building,
+            parser::CityObjectType::BuildingPart,
+        ]);
+        let feature_filter = build_feature_filter(cityobject_types.as_ref(), &BTreeMap::new());
         let mut world = parser::World::from_cjindex(
             parser::InputSource::from_cjindex_resolved(&resolved),
             metadata_path,
             feature_base_document,
             200,
-            Some(vec![
-                parser::CityObjectType::Building,
-                parser::CityObjectType::BuildingPart,
-            ]),
+            cityobject_types,
+            feature_filter,
             None,
             None,
         )
@@ -2597,14 +2719,8 @@ mod tests {
         let quadtree = build_quadtree(&world);
         let feature_ids = collect_tile_feature_ids(&world, &quadtree);
 
-        let model = build_tile_model_from_feature_ids(
-            &world,
-            &feature_ids,
-            &BTreeMap::new(),
-            &BTreeMap::new(),
-            true,
-        )
-        .expect("build tile model with inherited attributes");
+        let model = build_tile_model_from_feature_ids(&world, &feature_ids, &BTreeMap::new(), true)
+            .expect("build tile model with inherited attributes");
         let model_feature = feature_json(&model);
 
         assert_eq!(
@@ -2641,12 +2757,15 @@ mod tests {
         let feature_base_document = derive_base_document(&city_index).expect("derive base doc");
         fs::write(&metadata_path, &feature_base_document).expect("write metadata");
 
+        let cityobject_types = Some(vec![parser::CityObjectType::BuildingPart]);
+        let feature_filter = build_feature_filter(cityobject_types.as_ref(), &BTreeMap::new());
         let mut world = parser::World::from_cjindex(
             parser::InputSource::from_cjindex_resolved(&resolved),
             metadata_path,
             feature_base_document,
             200,
-            Some(vec![parser::CityObjectType::BuildingPart]),
+            cityobject_types,
+            feature_filter,
             None,
             None,
         )
@@ -2655,14 +2774,8 @@ mod tests {
         let quadtree = build_quadtree(&world);
         let feature_ids = collect_tile_feature_ids(&world, &quadtree);
 
-        let model = build_tile_model_from_feature_ids(
-            &world,
-            &feature_ids,
-            &BTreeMap::new(),
-            &BTreeMap::new(),
-            true,
-        )
-        .expect("build tile model with inherited attributes");
+        let model = build_tile_model_from_feature_ids(&world, &feature_ids, &BTreeMap::new(), true)
+            .expect("build tile model with inherited attributes");
         let model_feature = feature_json(&model);
 
         assert_eq!(
@@ -2681,6 +2794,101 @@ mod tests {
             Some(1)
         );
         assert_eq!(feature_root_id(&model), Some("building-part".to_string()));
+    }
+
+    #[test]
+    fn single_building_type_filter_retains_child_geometry_for_tiles() {
+        let dataset_dir = unique_test_dir("building-parent-child-geometry");
+        let features_dir = dataset_dir.join("features");
+        fs::create_dir_all(&features_dir).expect("create features dir");
+        let metadata_path = dataset_dir.join("metadata.json");
+        let feature_path = features_dir.join("sample.city.jsonl");
+        fs::copy(resource_path("3dbag_x00.city.json"), &metadata_path).expect("copy metadata");
+        fs::write(
+            &feature_path,
+            parent_attribute_remapping_fixture_bytes(serde_json::json!({})),
+        )
+        .expect("write feature");
+
+        let resolved = cityjson_index::resolve_dataset(&dataset_dir, None)
+            .expect("resolve building-only parent-child dataset");
+        let mut city_index =
+            cityjson_index::CityIndex::open(resolved.storage_layout(), &resolved.index_path)
+                .expect("open index");
+        city_index.reindex().expect("reindex");
+        let feature_base_document = derive_base_document(&city_index).expect("derive base doc");
+        fs::write(&metadata_path, &feature_base_document).expect("write metadata");
+
+        let cityobject_types = Some(vec![parser::CityObjectType::Building]);
+        let feature_filter = build_feature_filter(cityobject_types.as_ref(), &BTreeMap::new());
+        let mut world = parser::World::from_cjindex(
+            parser::InputSource::from_cjindex_resolved(&resolved),
+            metadata_path,
+            feature_base_document,
+            200,
+            cityobject_types,
+            feature_filter,
+            None,
+            None,
+        )
+        .expect("build building-only world");
+        world.index_with_grid().expect("index building-only world");
+        let quadtree = build_quadtree(&world);
+        let feature_ids = collect_tile_feature_ids(&world, &quadtree);
+
+        let model =
+            build_tile_model_from_feature_ids(&world, &feature_ids, &BTreeMap::new(), false)
+                .expect("build tile model");
+        let retained = retained_lods_by_object_id(&model);
+
+        assert!(retained
+            .get("building-part")
+            .is_some_and(|lods| !lods.is_empty() && lods.iter().all(|lod| lod == "1")));
+        assert!(model.vertices().len() >= 3);
+    }
+
+    #[test]
+    fn world_from_cjindex_errors_before_export_when_explicit_lod_is_missing() {
+        let dataset_dir = unique_test_dir("missing-explicit-lod");
+        let features_dir = dataset_dir.join("features");
+        fs::create_dir_all(&features_dir).expect("create features dir");
+        let metadata_path = dataset_dir.join("metadata.json");
+        let feature_path = features_dir.join("sample.city.jsonl");
+        fs::copy(resource_path("3dbag_x00.city.json"), &metadata_path).expect("copy metadata");
+        fs::write(
+            &feature_path,
+            parent_attribute_remapping_fixture_bytes(serde_json::json!({})),
+        )
+        .expect("write feature");
+
+        let resolved = cityjson_index::resolve_dataset(&dataset_dir, None)
+            .expect("resolve missing-lod dataset");
+        let mut city_index =
+            cityjson_index::CityIndex::open(resolved.storage_layout(), &resolved.index_path)
+                .expect("open index");
+        city_index.reindex().expect("reindex");
+        let feature_base_document = derive_base_document(&city_index).expect("derive base doc");
+        fs::write(&metadata_path, &feature_base_document).expect("write metadata");
+
+        let lods = BTreeMap::from([("BuildingPart".to_string(), "99".to_string())]);
+        let feature_filter = build_feature_filter(None, &lods);
+        let Err(error) = parser::World::from_cjindex(
+            parser::InputSource::from_cjindex_resolved(&resolved),
+            metadata_path,
+            feature_base_document,
+            200,
+            None,
+            feature_filter,
+            None,
+            None,
+        ) else {
+            panic!("missing explicit LoD should fail before grid/export");
+        };
+        let message = error.to_string();
+
+        assert!(message.contains("requested LoD selector matched no geometry"));
+        assert!(message.contains("BuildingPart requested LoD '99'"));
+        assert!(message.contains("available LoDs are: 1"));
     }
 
     #[test]
@@ -2734,12 +2942,14 @@ mod tests {
         let metadata_path = dataset_dir.join("metadata.city.json");
         fs::write(&metadata_path, &feature_base_document).expect("write metadata");
 
+        let feature_filter = build_feature_filter(None, &BTreeMap::new());
         let mut world = parser::World::from_cjindex(
             parser::InputSource::from_cjindex_resolved(&resolved),
             metadata_path,
             feature_base_document,
             200,
             None,
+            feature_filter,
             None,
             None,
         )
@@ -2781,12 +2991,14 @@ mod tests {
         let metadata_path = dataset_dir.join("metadata.city.json");
         fs::write(&metadata_path, &feature_base_document).expect("write metadata");
 
+        let feature_filter = build_feature_filter(None, &BTreeMap::new());
         let mut world = parser::World::from_cjindex(
             parser::InputSource::from_cjindex_resolved(&resolved),
             metadata_path,
             feature_base_document,
             200,
             None,
+            feature_filter,
             None,
             None,
         )
@@ -2830,12 +3042,15 @@ mod tests {
         let metadata_path = dataset_dir.join("metadata.city.json");
         fs::write(&metadata_path, &feature_base_document).expect("write metadata");
 
+        let cityobject_types = Some(vec![parser::CityObjectType::Building]);
+        let feature_filter = build_feature_filter(cityobject_types.as_ref(), &BTreeMap::new());
         let mut world = parser::World::from_cjindex(
             parser::InputSource::from_cjindex_resolved(&resolved),
             metadata_path,
             feature_base_document,
             200,
-            Some(vec![parser::CityObjectType::Building]),
+            cityobject_types,
+            feature_filter,
             None,
             None,
         )
@@ -2924,12 +3139,15 @@ mod tests {
         let metadata_path = dataset_dir.join("metadata.city.json");
         fs::write(&metadata_path, &feature_base_document).expect("write metadata");
 
+        let cityobject_types = Some(vec![parser::CityObjectType::Building]);
+        let feature_filter = build_feature_filter(cityobject_types.as_ref(), &BTreeMap::new());
         let mut world = parser::World::from_cjindex(
             parser::InputSource::from_cjindex_resolved(&resolved),
             metadata_path,
             feature_base_document,
             200,
-            Some(vec![parser::CityObjectType::Building]),
+            cityobject_types,
+            feature_filter,
             None,
             None,
         )

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -41,6 +41,7 @@ thread_local! {
 #[derive(Serialize, Deserialize)]
 pub struct World {
     pub cityobject_types: Option<Vec<CityObjectType>>,
+    pub feature_filter: cityjson_index::FeatureFilter,
     pub crs: Crs,
     pub features: FeatureSet,
     pub feature_base_document: Vec<u8>,
@@ -69,10 +70,16 @@ struct ExtentStats {
     nr_features: usize,
     nr_features_ignored: usize,
     cityobject_types_ignored: Vec<CityObjectType>,
+    filter_summary: cityjson_index::FeatureFilterSummary,
 }
 
 impl ExtentStats {
-    fn add_selected_geometry_stats(&mut self, stats: SelectedGeometryStats) {
+    fn add_selected_geometry_stats(
+        &mut self,
+        stats: SelectedGeometryStats,
+        diagnostics: &cityjson_index::FeatureFilterDiagnostics,
+    ) {
+        self.filter_summary.add(diagnostics);
         if let Some(model_bbox) = stats.bbox {
             if let Some(current) = self.extent.as_mut() {
                 merge_bbox(current, &model_bbox);
@@ -97,6 +104,7 @@ impl ExtentStats {
         self.nr_features += other.nr_features;
         self.nr_features_ignored += other.nr_features_ignored;
         self.extend_ignored_types(other.cityobject_types_ignored);
+        merge_filter_summary(&mut self.filter_summary, other.filter_summary);
     }
 
     fn extend_ignored_types(&mut self, ignored_types: Vec<CityObjectType>) {
@@ -105,6 +113,29 @@ impl ExtentStats {
                 self.cityobject_types_ignored.push(cotype);
             }
         }
+    }
+}
+
+fn merge_filter_summary(
+    target: &mut cityjson_index::FeatureFilterSummary,
+    source: cityjson_index::FeatureFilterSummary,
+) {
+    target.available_types.extend(source.available_types);
+    target.retained_types.extend(source.retained_types);
+    target.ignored_types.extend(source.ignored_types);
+    merge_lod_summary(&mut target.available_lods, source.available_lods);
+    merge_lod_summary(&mut target.retained_lods, source.retained_lods);
+    target.missing_lods.extend(source.missing_lods);
+    target.retained_feature_count += source.retained_feature_count;
+    target.ignored_feature_count += source.ignored_feature_count;
+}
+
+fn merge_lod_summary(
+    target: &mut BTreeMap<String, std::collections::BTreeSet<String>>,
+    source: BTreeMap<String, std::collections::BTreeSet<String>>,
+) {
+    for (cityobject_type, lods) in source {
+        target.entry(cityobject_type).or_default().extend(lods);
     }
 }
 
@@ -169,6 +200,7 @@ impl World {
         feature_base_document: Vec<u8>,
         cellsize: u32,
         cityobject_types: Option<Vec<CityObjectType>>,
+        feature_filter: cityjson_index::FeatureFilter,
         arg_minz: Option<i32>,
         arg_maxz: Option<i32>,
     ) -> Result<Self, Box<dyn std::error::Error>> {
@@ -176,22 +208,27 @@ impl World {
         let crs = Crs::from_model(&metadata)?;
 
         info!(
-            "Computing extent from the features of type {:?}",
-            cityobject_types
+            "Computing extent from features with CityObject types {:?} and LoD filter {:?}",
+            cityobject_types, feature_filter
         );
 
-        let (extent, nr_features, nr_features_ignored, cityobject_types_ignored) =
-            if cityobject_types.is_none() {
+        let (extent, nr_features, nr_features_ignored, cityobject_types_ignored, filter_summary) =
+            if feature_filter.is_active() {
+                Self::extent_from_cjindex_features(
+                    &input_source,
+                    cityobject_types.as_ref(),
+                    &feature_filter,
+                )?
+            } else {
                 let city_index = input_source.open_index()?;
                 Self::extent_from_cjindex_bbox_pages(&city_index)?
-            } else {
-                Self::extent_from_cjindex_features(&input_source, cityobject_types.as_ref())?
             };
+        filter_summary.ensure_requested_lods_available(&feature_filter)?;
 
         let mut extent = extent.ok_or_else(|| {
             format!(
-                "Did not find any CityJSONFeatures of type {:?} in cjindex dataset",
-                cityobject_types
+                "Did not find any CityJSONFeatures matching CityObject types {:?} and LoD filter {:?} in cjindex dataset",
+                cityobject_types, feature_filter
             )
         })?;
 
@@ -214,6 +251,22 @@ impl World {
             "Ignored {} features of type {:?}",
             nr_features_ignored, &cityobject_types_ignored
         );
+        info!(
+            "Available CityObject types after scan: {:?}",
+            filter_summary.available_types
+        );
+        info!(
+            "Retained CityObject types after filtering: {:?}",
+            filter_summary.retained_types
+        );
+        info!(
+            "Available LoDs by CityObject type after filtering: {:?}",
+            filter_summary.available_lods
+        );
+        info!(
+            "Retained LoDs by CityObject type after filtering: {:?}",
+            filter_summary.retained_lods
+        );
         debug!("extent: {:?}", &extent);
         info!(
             "Computed extent from features: {}",
@@ -227,6 +280,7 @@ impl World {
             features: Vec::with_capacity(nr_features),
             crs,
             feature_base_document,
+            feature_filter,
             grid,
             cityobject_types,
             path_metadata,
@@ -234,24 +288,20 @@ impl World {
         })
     }
 
-    fn extent_from_cjindex_bbox_pages(
-        city_index: &CityIndex,
-    ) -> Result<(Option<Bbox>, usize, usize, Vec<CityObjectType>), Box<dyn std::error::Error>> {
-        let Some(summary) = city_index.feature_bounds_summary()? else {
-            return Ok((None, 0, 0, Vec::new()));
-        };
-        Ok((
-            Some(Self::cjindex_bounds_to_world_bbox(&summary.bounds)),
-            summary.feature_count,
-            0,
-            Vec::new(),
-        ))
-    }
-
     fn extent_from_cjindex_features(
         input_source: &InputSource,
         cityobject_types: Option<&Vec<CityObjectType>>,
-    ) -> Result<(Option<Bbox>, usize, usize, Vec<CityObjectType>), Box<dyn std::error::Error>> {
+        feature_filter: &cityjson_index::FeatureFilter,
+    ) -> Result<
+        (
+            Option<Bbox>,
+            usize,
+            usize,
+            Vec<CityObjectType>,
+            cityjson_index::FeatureFilterSummary,
+        ),
+        Box<dyn std::error::Error>,
+    > {
         let city_index = input_source.open_index()?;
         let (chunk_tx, chunk_rx) =
             std::sync::mpsc::sync_channel::<Vec<cityjson_index::IndexedFeatureRef>>(64);
@@ -283,6 +333,7 @@ impl World {
                         input_source,
                         &chunk,
                         cityobject_types,
+                        feature_filter,
                     )
                 })
                 .try_reduce(ExtentStats::default, |mut a, b| {
@@ -299,21 +350,38 @@ impl World {
             total.nr_features,
             total.nr_features_ignored,
             total.cityobject_types_ignored,
+            total.filter_summary,
         ))
     }
 
-    fn extent_from_cjindex_feature_refs_chunk(
-        input_source: &InputSource,
-        feature_refs: &[cityjson_index::IndexedFeatureRef],
-        cityobject_types: Option<&Vec<CityObjectType>>,
-    ) -> Result<ExtentStats, std::io::Error> {
-        let models = Self::read_cjindex_features_thread_local(input_source, feature_refs)
-            .map_err(|error| std::io::Error::other(error.to_string()))?;
-        let mut chunk = ExtentStats::default();
-        for model in models {
-            chunk.add_selected_geometry_stats(selected_geometry_stats(&model, cityobject_types));
-        }
-        Ok(chunk)
+    fn extent_from_cjindex_bbox_pages(
+        city_index: &CityIndex,
+    ) -> Result<
+        (
+            Option<Bbox>,
+            usize,
+            usize,
+            Vec<CityObjectType>,
+            cityjson_index::FeatureFilterSummary,
+        ),
+        Box<dyn std::error::Error>,
+    > {
+        let Some(summary) = city_index.feature_bounds_summary()? else {
+            return Ok((
+                None,
+                0,
+                0,
+                Vec::new(),
+                cityjson_index::FeatureFilterSummary::default(),
+            ));
+        };
+        Ok((
+            Some(Self::cjindex_bounds_to_world_bbox(&summary.bounds)),
+            summary.feature_count,
+            0,
+            Vec::new(),
+            cityjson_index::FeatureFilterSummary::default(),
+        ))
     }
 
     fn cjindex_bounds_to_world_bbox(bounds: &cityjson_index::FeatureBounds) -> Bbox {
@@ -325,6 +393,28 @@ impl World {
             bounds.max_y,
             bounds.max_z,
         ]
+    }
+
+    fn extent_from_cjindex_feature_refs_chunk(
+        input_source: &InputSource,
+        feature_refs: &[cityjson_index::IndexedFeatureRef],
+        _cityobject_types: Option<&Vec<CityObjectType>>,
+        feature_filter: &cityjson_index::FeatureFilter,
+    ) -> Result<ExtentStats, std::io::Error> {
+        let filtered_features = Self::read_filtered_cjindex_features_thread_local(
+            input_source,
+            feature_refs,
+            feature_filter,
+        )
+        .map_err(|error| std::io::Error::other(error.to_string()))?;
+        let mut chunk = ExtentStats::default();
+        for filtered in filtered_features {
+            chunk.add_selected_geometry_stats(
+                selected_geometry_stats(&filtered.model, None),
+                &filtered.diagnostics,
+            );
+        }
+        Ok(chunk)
     }
 
     pub(crate) fn read_cjindex_features_thread_local(
@@ -359,6 +449,39 @@ impl World {
         })
     }
 
+    fn read_filtered_cjindex_features_thread_local(
+        input_source: &InputSource,
+        features: &[cityjson_index::IndexedFeatureRef],
+        filter: &cityjson_index::FeatureFilter,
+    ) -> cityjson_lib::Result<Vec<cityjson_index::FilteredFeature>> {
+        let index_path = &input_source.index_path;
+
+        CJINDEX_THREAD_LOCAL.with(|cell| {
+            let needs_open = {
+                let slot = cell.borrow();
+                match slot.as_ref() {
+                    Some((cached_index_path, _)) => cached_index_path != index_path,
+                    None => true,
+                }
+            };
+
+            if needs_open {
+                let city_index = input_source.open_index().map_err(|error| {
+                    cityjson_lib::Error::Io(std::io::Error::other(error.to_string()))
+                })?;
+                *cell.borrow_mut() = Some((index_path.clone(), city_index));
+            }
+
+            let slot = cell.borrow();
+            let Some((_, city_index)) = slot.as_ref() else {
+                return Err(cityjson_lib::Error::Io(std::io::Error::other(
+                    "cjindex thread-local index cache was not initialized",
+                )));
+            };
+            city_index.read_filtered_features(features, filter)
+        })
+    }
+
     pub fn index_with_grid(&mut self) -> Result<(), Box<dyn std::error::Error>> {
         info!("Counting vertices in grid cells");
 
@@ -373,6 +496,7 @@ impl World {
         let grid: &mut crate::spatial_structs::SquareGrid = &mut self.grid;
         let input_source: &InputSource = &self.input_source;
         let cityobject_types: Option<&Vec<CityObjectType>> = self.cityobject_types.as_ref();
+        let feature_filter: &cityjson_index::FeatureFilter = &self.feature_filter;
         let grid_layout = grid.layout();
 
         let (chunk_tx, chunk_rx) =
@@ -422,6 +546,7 @@ impl World {
                             input_source,
                             &grid_layout,
                             cityobject_types,
+                            feature_filter,
                             &chunk,
                         );
                         let _ = tx.send(result);
@@ -466,34 +591,43 @@ impl World {
         input_source: &InputSource,
         grid_layout: &GridLayout,
         cityobject_types: Option<&Vec<CityObjectType>>,
+        feature_filter: &cityjson_index::FeatureFilter,
         feature_refs: &[cityjson_index::IndexedFeatureRef],
     ) -> Result<Vec<Option<FeatureInGridCells>>, std::io::Error> {
-        let models = Self::read_cjindex_features_thread_local(input_source, feature_refs)
-            .map_err(|error| std::io::Error::other(error.to_string()))?;
-        Ok(feature_refs
+        let filtered_features = Self::read_filtered_cjindex_features_thread_local(
+            input_source,
+            feature_refs,
+            feature_filter,
+        )
+        .map_err(|error| std::io::Error::other(error.to_string()))?;
+        feature_refs
             .iter()
             .cloned()
-            .zip(models.iter())
-            .map(|(feature_ref, model)| {
+            .zip(filtered_features.iter())
+            .map(|(feature_ref, filtered)| {
                 Self::index_feature_model(
                     grid_layout,
                     cityobject_types,
                     FeatureReference::CjIndexRef(feature_ref),
-                    model,
+                    &filtered.model,
                 )
             })
-            .collect())
+            .collect::<Result<Vec<_>, _>>()
     }
 
     fn index_feature_model(
         grid_layout: &GridLayout,
-        cityobject_types: Option<&Vec<CityObjectType>>,
+        _cityobject_types: Option<&Vec<CityObjectType>>,
         feature_reference: FeatureReference,
         model: &cityjson_lib::CityModel,
-    ) -> Option<FeatureInGridCells> {
-        let stats = selected_geometry_stats(model, cityobject_types);
-        let bbox = stats.bbox?;
-        let centroid = stats.centroid?;
+    ) -> Result<Option<FeatureInGridCells>, std::io::Error> {
+        let stats = selected_geometry_stats(model, None);
+        let Some(bbox) = stats.bbox else {
+            return Ok(None);
+        };
+        let Some(centroid) = stats.centroid else {
+            return Ok(None);
+        };
 
         let uses_unique_assignment =
             selected_types_use_unique_assignment(&stats.selected_object_types);
@@ -501,21 +635,28 @@ impl World {
             centroid,
             reference: feature_reference,
             bbox,
-            needs_type_filter: !stats.ignored_object_types.is_empty(),
+            needs_type_filter: false,
         };
 
         if uses_unique_assignment {
-            let (cellid, nr_vertices) =
-                count_unique_assignment_cell(model, &stats.selected_vertices, grid_layout, &bbox)?;
-            return Some(Self::feature_to_unique_cell(feature, cellid, nr_vertices));
+            let Some((cellid, nr_vertices)) =
+                count_unique_assignment_cell(model, &stats.selected_vertices, grid_layout, &bbox)
+            else {
+                return Ok(None);
+            };
+            return Ok(Some(Self::feature_to_unique_cell(
+                feature,
+                cellid,
+                nr_vertices,
+            )));
         }
 
         let cell_vtx_cnt =
             count_vertices_in_grid(model, &stats.selected_vertices, grid_layout, &bbox);
         if cell_vtx_cnt.is_empty() {
-            return None;
+            return Ok(None);
         }
-        Self::feature_to_cells(feature, cell_vtx_cnt)
+        Ok(Self::feature_to_cells(feature, cell_vtx_cnt))
     }
 
     fn feature_to_cells(feature: Feature, cell_vtx_cnt: CellCounts) -> Option<FeatureInGridCells> {
@@ -1057,14 +1198,17 @@ impl CellCounts {
     }
 }
 
-fn is_selected_type(filter: Option<&Vec<CityObjectType>>, object_type: CityObjectType) -> bool {
+pub(crate) fn is_selected_type(
+    filter: Option<&Vec<CityObjectType>>,
+    object_type: CityObjectType,
+) -> bool {
     match filter {
         Some(types) => types.contains(&object_type),
         None => true,
     }
 }
 
-fn map_cityobject_type<SS: cityjson::resources::storage::StringStorage>(
+pub(crate) fn map_cityobject_type<SS: cityjson::resources::storage::StringStorage>(
     object_type: &cityjson::v2_0::CityObjectType<SS>,
 ) -> Option<CityObjectType> {
     use cityjson::v2_0::CityObjectType as CjType;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -491,14 +491,7 @@ impl World {
         feature_reference: FeatureReference,
         model: &cityjson_lib::CityModel,
     ) -> Option<FeatureInGridCells> {
-        let stats_started = Instant::now();
         let stats = selected_geometry_stats(model, cityobject_types);
-        debug!(
-            "selected_geometry_stats collected {} vertices for {:?} in {:?}",
-            stats.selected_vertices.len(),
-            feature_reference,
-            stats_started.elapsed()
-        );
         let bbox = stats.bbox?;
         let centroid = stats.centroid?;
 
@@ -512,27 +505,13 @@ impl World {
         };
 
         if uses_unique_assignment {
-            let count_started = Instant::now();
             let (cellid, nr_vertices) =
                 count_unique_assignment_cell(model, &stats.selected_vertices, grid_layout, &bbox)?;
-            debug!(
-                "Selected unique assignment grid cell {:?} with {} vertices in {:?}",
-                cellid,
-                nr_vertices,
-                count_started.elapsed()
-            );
             return Some(Self::feature_to_unique_cell(feature, cellid, nr_vertices));
         }
 
-        let count_started = Instant::now();
         let cell_vtx_cnt =
             count_vertices_in_grid(model, &stats.selected_vertices, grid_layout, &bbox);
-        debug!(
-            "Counted {} grid cells for {:?} in {:?}",
-            cell_vtx_cnt.len(),
-            feature.reference,
-            count_started.elapsed()
-        );
         if cell_vtx_cnt.is_empty() {
             return None;
         }

--- a/tests/cli_debug_behavior.rs
+++ b/tests/cli_debug_behavior.rs
@@ -346,3 +346,83 @@ fn object_attributes_filter_and_type_glb_metadata_schema() {
     );
     assert!(!properties.contains_key("ignored"));
 }
+
+#[test]
+fn object_type_building_single_tile_tileset_keeps_positive_root_geometric_error() {
+    let metadata = read_fixture("resources/data/3dbag_x00.city.json");
+    let feature = serde_json::json!({
+        "type": "CityJSONFeature",
+        "id": "single-building",
+        "transform": {
+            "scale": [1.0, 1.0, 1.0],
+            "translate": [0.0, 0.0, 0.0]
+        },
+        "CityObjects": {
+            "building": {
+                "type": "Building",
+                "attributes": {
+                    "name": "Single building"
+                },
+                "geometry": [{
+                    "type": "MultiSurface",
+                    "lod": "1",
+                    "boundaries": [[[0, 1, 2], [0, 2, 3]]]
+                }]
+            }
+        },
+        "vertices": [
+            [0, 0, 0],
+            [4, 0, 0],
+            [4, 4, 0],
+            [0, 4, 0]
+        ]
+    })
+    .to_string();
+    let dataset = write_ndjson_dataset("object-type-building-single", &metadata, &[feature]);
+    let output_dir = unique_test_dir("object-type-building-single-output");
+
+    let output = run_tyler(&dataset, &output_dir, &["--object-type", "Building"]);
+    assert_success(&output, "single building tileset run");
+
+    let tileset = read_json(&output_dir.join("tileset.json"));
+    let root = &tileset["root"];
+    assert!(root["content"].is_object(), "root tile should keep content");
+    assert!(
+        root.get("children").is_none(),
+        "single-building dataset should produce a single root tile"
+    );
+    let root_geometric_error = root["geometricError"]
+        .as_f64()
+        .expect("root geometricError should be numeric");
+    assert!(
+        root_geometric_error.abs() <= f64::EPSILON,
+        "root tile geometricError can remain zero"
+    );
+    let tileset_geometric_error = tileset["geometricError"]
+        .as_f64()
+        .expect("tileset geometricError should be numeric");
+    assert!(
+        tileset_geometric_error > 0.0,
+        "tileset geometricError should stay positive for a single-tile tileset"
+    );
+    assert!(tileset_geometric_error > f64::EPSILON);
+
+    let unpruned_tileset = read_json(&output_dir.join("tileset_unpruned.json"));
+    let unpruned_root = &unpruned_tileset["root"];
+    assert!(unpruned_root["content"].is_object());
+    let unpruned_root_geometric_error = unpruned_root["geometricError"]
+        .as_f64()
+        .expect("unpruned root geometricError should be numeric");
+    assert!(
+        unpruned_root_geometric_error.abs() <= f64::EPSILON,
+        "unpruned root geometricError can remain zero"
+    );
+    let unpruned_tileset_geometric_error = unpruned_tileset["geometricError"]
+        .as_f64()
+        .expect("unpruned tileset geometricError should be numeric");
+    assert!(
+        unpruned_tileset_geometric_error > 0.0,
+        "unpruned tileset geometricError should stay positive"
+    );
+    assert!(unpruned_tileset_geometric_error > f64::EPSILON);
+}


### PR DESCRIPTION
- Consolidate the CityObject filtering logic and move it to cityjson-index , so that filtering happens before extent, grid, tile, and export decisions, so tile bounds and output content use the same retained geometry.
- Missing explicit `--lod-*` selections now fail before tile export with diagnostics for available LoDs instead of producing empty tile models late in the pipeline.
- `--object-type Building` filtering now keeps descendant geometry such as `BuildingPart` objects when those children are part of the selected building hierarchy.
- Fix top-level geometricError being zero in case of a single-leaf tileset.
- Exit early if the input does not contain the selected lod.