### PR TITLE
Add CLI format validation gate

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -244,6 +244,35 @@ pub struct Cli {
     // pub exe_python: Option<PathBuf>,
 }
 
+impl Cli {
+    /// Central gate for rejecting CLI option combinations that are incompatible
+    /// with one or more selected output formats.
+    ///
+    /// This validation must run after clap parsing but before output directory
+    /// creation, input inspection, indexing, grid construction, or tile
+    /// processing. It intentionally accepts a format slice so future
+    /// multi-format CLI support can validate every selected format with the
+    /// same mechanism.
+    ///
+    /// The gate may start as a no-op until format-specific rules are added.
+    #[allow(clippy::unused_self)]
+    pub fn validate_parameter_combinations(
+        &self,
+        formats: &[crate::OutputFormatKind],
+    ) -> Result<(), String> {
+        for &format in formats {
+            Self::validate_parameter_combinations_for_format(format)?;
+        }
+        Ok(())
+    }
+
+    fn validate_parameter_combinations_for_format(
+        _format: crate::OutputFormatKind,
+    ) -> Result<(), String> {
+        Ok(())
+    }
+}
+
 fn existing_canonical_path(s: &str) -> Result<PathBuf, String> {
     if let Ok(c) = Path::new(s).canonicalize() {
         if c.exists() {
@@ -275,6 +304,7 @@ fn hex_color(s: &str) -> Result<String, String> {
 #[cfg(test)]
 mod tests {
     use super::Cli;
+    use crate::OutputFormatKind;
     use clap::{CommandFactory, Parser};
     use std::fs;
     use std::path::{Path, PathBuf};
@@ -413,6 +443,35 @@ mod tests {
                 .canonicalize()
                 .unwrap()
         );
+    }
+
+    #[test]
+    fn validation_accepts_default_format() {
+        let cli = Cli::try_parse_from(dataset_args()).unwrap();
+
+        assert!(cli.validate_parameter_combinations(&[cli.format]).is_ok());
+    }
+
+    #[test]
+    fn validation_accepts_explicit_non_default_format() {
+        let mut args = dataset_args();
+        args.extend(["--format".to_string(), "cityjson".to_string()]);
+        let cli = Cli::try_parse_from(args).unwrap();
+
+        assert!(cli.validate_parameter_combinations(&[cli.format]).is_ok());
+    }
+
+    #[test]
+    fn validation_accepts_multiple_formats_directly() {
+        let cli = Cli::try_parse_from(dataset_args()).unwrap();
+
+        assert!(cli
+            .validate_parameter_combinations(&[
+                OutputFormatKind::Cesium3dTiles,
+                OutputFormatKind::Cityjson,
+                OutputFormatKind::Cityjsonseq,
+            ])
+            .is_ok());
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -14,6 +14,7 @@
 use std::path::{Path, PathBuf};
 
 use clap::Parser;
+use log::info;
 
 #[derive(Parser, Debug)]
 #[command(author, version, about)]
@@ -244,6 +245,32 @@ pub struct Cli {
     // pub exe_python: Option<PathBuf>,
 }
 
+#[derive(Clone, Copy)]
+struct NoEffectInfoRule {
+    flag: &'static str,
+    n_a_formats: &'static [crate::OutputFormatKind],
+    is_present: fn(&Cli) -> bool,
+}
+
+const NO_EFFECT_INFO_RULES: &[NoEffectInfoRule] = &[
+    NoEffectInfoRule {
+        flag: "--grid-minz",
+        n_a_formats: &[
+            crate::OutputFormatKind::Cityjson,
+            crate::OutputFormatKind::Cityjsonseq,
+        ],
+        is_present: cli_has_grid_minz,
+    },
+    NoEffectInfoRule {
+        flag: "--grid-maxz",
+        n_a_formats: &[
+            crate::OutputFormatKind::Cityjson,
+            crate::OutputFormatKind::Cityjsonseq,
+        ],
+        is_present: cli_has_grid_maxz,
+    },
+];
+
 impl Cli {
     /// Central gate for rejecting CLI option combinations that are incompatible
     /// with one or more selected output formats.
@@ -260,16 +287,62 @@ impl Cli {
         &self,
         formats: &[crate::OutputFormatKind],
     ) -> Result<(), String> {
-        for &format in formats {
-            Self::validate_parameter_combinations_for_format(format)?;
+        for message in self.no_effect_info_messages(formats) {
+            info!("{message}");
         }
         Ok(())
     }
 
-    fn validate_parameter_combinations_for_format(
-        _format: crate::OutputFormatKind,
-    ) -> Result<(), String> {
-        Ok(())
+    fn no_effect_info_messages(&self, formats: &[crate::OutputFormatKind]) -> Vec<String> {
+        let selected_formats = unique_output_formats(formats);
+        let selected_format_names = selected_formats
+            .iter()
+            .map(|format| output_format_name(*format))
+            .collect::<Vec<_>>()
+            .join(", ");
+
+        NO_EFFECT_INFO_RULES
+            .iter()
+            .filter(|rule| {
+                (rule.is_present)(self)
+                    && selected_formats
+                        .iter()
+                        .all(|format| rule.n_a_formats.contains(format))
+            })
+            .map(|rule| {
+                format!(
+                    "{} has no effect for selected output formats: {}",
+                    rule.flag, selected_format_names
+                )
+            })
+            .collect()
+    }
+}
+
+fn cli_has_grid_minz(cli: &Cli) -> bool {
+    cli.grid_minz.is_some()
+}
+
+fn cli_has_grid_maxz(cli: &Cli) -> bool {
+    cli.grid_maxz.is_some()
+}
+
+fn unique_output_formats(formats: &[crate::OutputFormatKind]) -> Vec<crate::OutputFormatKind> {
+    let mut unique_formats = Vec::new();
+    for &format in formats {
+        if !unique_formats.contains(&format) {
+            unique_formats.push(format);
+        }
+    }
+    unique_formats.sort_unstable_by_key(|format| output_format_name(*format));
+    unique_formats
+}
+
+fn output_format_name(format: crate::OutputFormatKind) -> &'static str {
+    match format {
+        crate::OutputFormatKind::Cesium3dTiles => "3dtiles",
+        crate::OutputFormatKind::Cityjson => "cityjson",
+        crate::OutputFormatKind::Cityjsonseq => "cityjsonseq",
     }
 }
 
@@ -472,6 +545,46 @@ mod tests {
                 OutputFormatKind::Cityjsonseq,
             ])
             .is_ok());
+    }
+
+    #[test]
+    fn n_a_flag_emits_one_info_message_for_selected_formats() {
+        let mut cli = Cli::try_parse_from(dataset_args()).unwrap();
+        cli.grid_minz = Some(-10);
+
+        assert_eq!(
+            cli.no_effect_info_messages(&[
+                OutputFormatKind::Cityjson,
+                OutputFormatKind::Cityjsonseq,
+            ]),
+            vec![
+                "--grid-minz has no effect for selected output formats: cityjson, cityjsonseq"
+                    .to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn supported_format_suppresses_no_op_info_message() {
+        let mut cli = Cli::try_parse_from(dataset_args()).unwrap();
+        cli.grid_minz = Some(-10);
+
+        assert!(cli
+            .no_effect_info_messages(
+                &[OutputFormatKind::Cesium3dTiles, OutputFormatKind::Cityjson,]
+            )
+            .is_empty());
+    }
+
+    #[test]
+    fn default_single_format_path_still_behaves_correctly() {
+        let mut cli = Cli::try_parse_from(dataset_args()).unwrap();
+        cli.grid_minz = Some(-10);
+
+        assert!(cli
+            .no_effect_info_messages(&[OutputFormatKind::Cesium3dTiles])
+            .is_empty());
+        assert!(cli.validate_parameter_combinations(&[cli.format]).is_ok());
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1867,6 +1867,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // --- Begin argument parsing
     let cli = crate::cli::Cli::parse();
+    cli.validate_parameter_combinations(&[cli.format])?;
     debug!("{:?}", &cli);
     info!("tyler version: {}", clap::crate_version!());
     if !cli.output.is_dir() {


### PR DESCRIPTION
Add CLI argument validation based on the argument matrix in ADR 011. The validation is not blocking, just informative/warning in case an argument is used that has no effect for the selected formats.

If we allow multiple formats, we cannot really have blocking argument validation i think.

Closes #119