### PR TITLE
OBJ output and modularise triangulation + clipping

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,8 +470,8 @@ Profiling Dependencies:
 - [x] Additional export formats:
     - [x] CityJSON
     - [x] CityJSONSeq
+    - [x] Wavefront OBJ
 - [ ] Additional export formats:
-    - [ ] Wavefront OBJ
     - [ ] GeoPackage
 
 ## Funding

--- a/README.md
+++ b/README.md
@@ -150,11 +150,12 @@ give Tyler a dataset root that `cjindex` can resolve.
 Tyler writes 3D Tiles by default. Select another output format with `--format`:
 
 - `3dtiles`: writes a 3D Tiles tileset and `.glb` tile content.
+- `obj`: writes one geometry-only Wavefront OBJ file per non-empty tile.
 - `cityjson`: writes one merged `CityJSON` document per non-empty tile.
 - `cityjsonseq`: writes one `CityJSONSeq` stream per non-empty tile, with a
   `CityJSON` header and one `CityJSONFeature` item per selected source feature.
 
-The tiled `CityJSON` and `CityJSONSeq` outputs use the same grid, quadtree,
+The tiled `OBJ`, `CityJSON` and `CityJSONSeq` outputs use the same grid, quadtree,
 feature filtering, LoD selection, attribute filtering and parent-attribute
 inheritance path as the 3D Tiles output. They do not write `tileset.json`,
 `subtrees/`, or 3D Tiles metadata.
@@ -197,6 +198,24 @@ tyler \
 The output tiles are written under `t/<level>/<x>/<y>.city.json`.
 Each tile is a merged `CityJSON` document containing the selected features for
 that tile.
+
+### Exporting OBJ
+
+Use `--format obj` to write tiled Wavefront OBJ files.
+
+```shell
+tyler \
+    /data \
+    --output /obj-tiles \
+    --format obj \
+    --object-type Building \
+    --object-type BuildingPart
+```
+
+The output tiles are written under `t/<level>/<x>/<y>.obj`. Each tile contains
+geometry-only OBJ records grouped by CityObject ID. Coordinates stay in the
+source CityJSON coordinate space; Tyler does not apply the 3D Tiles ENU
+placement or tile-bound clipping to OBJ output.
 
 ### Exporting CityJSONSeq
 
@@ -249,6 +268,7 @@ cjio combined.city.json upgrade save combined/combined_upg.city.json
 The output is written to the directory set in `--output`.
 For 3D Tiles output, it will contain a `tileset.json` file and `t/` directory with the glTF files.
 In case of implicit tiling, also a `subtrees/` directory is written with the subtrees.
+For `--format obj`, it will contain a `t/` directory with `.obj` tile files.
 For `--format cityjson`, it will contain a `t/` directory with `.city.json` tile files.
 For `--format cityjsonseq`, it will contain a `t/` directory with `.city.jsonl` tile files.
 

--- a/cityjson-convert/README.md
+++ b/cityjson-convert/README.md
@@ -2,7 +2,7 @@
 
 `cityjson-convert` converts CityJSON data to other formats.
 
-It supports GLB, CityJSON and CityJSONSeq output, both through the library API
+It supports GLB, OBJ, CityJSON and CityJSONSeq output, both through the library API
 and through the `cjconvert` CLI.
 
 By default, source builds use the `proj-system` feature, which enables
@@ -50,6 +50,20 @@ fn export(model: &CityModel) -> anyhow::Result<()> {
 }
 ```
 
+### OBJ
+
+```rust
+use cityjson_convert::{convert_to_obj, ObjExportOptions};
+use cityjson_lib::CityModel;
+
+fn export(model: &CityModel) -> anyhow::Result<()> {
+    convert_to_obj(model, "output/model.obj", &ObjExportOptions::default())
+}
+```
+
+OBJ output is geometry-only Wavefront OBJ grouped by CityObject ID. Coordinates
+are written in the source CityJSON coordinate space.
+
 ### CityJSONSeq
 
 ```rust
@@ -87,6 +101,12 @@ Convert a CityJSON file to a CityJSON file:
 
 ```shell
 cjconvert input.city.json --output output/model.city.json --format cityjson
+```
+
+Convert a CityJSON file to an OBJ file:
+
+```shell
+cjconvert input.city.json --output output/model.obj --format obj
 ```
 
 Convert a CityJSONSeq or CityJSONFeature stream to CityJSONSeq:

--- a/cityjson-convert/src/gltf_writer.rs
+++ b/cityjson-convert/src/gltf_writer.rs
@@ -6,12 +6,12 @@ use std::fs::File;
 use std::io::Write;
 use std::path::Path;
 
+use crate::triangle_mesh::{build_triangle_mesh, TriangleMeshOptions};
 use crate::{ExportOptions, GeographicClipRegion, GeometryPlacement};
 use anyhow::{bail, Context, Result};
-use cityjson_lib::cityjson_types::v2_0::{AttributeValue, CityObject, GeometryType, VertexIndex};
+use cityjson_lib::cityjson_types::v2_0::{AttributeValue, CityObject};
 use cityjson_lib::ops::Transformer;
 use cityjson_lib::CityModel;
-use earcutr::earcut;
 use gltf::json;
 use log::debug;
 use meshopt::{
@@ -79,51 +79,6 @@ fn create_default_material(base_color: &str) -> Result<json::Material, anyhow::E
         alpha_cutoff: None,
         double_sided: true,
     })
-}
-
-/// Strip consecutive bit-identical vertices from each ring
-/// before triangulation. earcutr 0.5.0 can spin forever on polygons that
-/// contain inner rings whose vertices repeat
-#[allow(clippy::float_cmp)]
-fn dedupe_polygon_rings(
-    flat_coords: &[f64],
-    hole_indices: &[usize],
-) -> (Vec<f64>, Vec<usize>, Vec<usize>) {
-    let mut ring_offsets: Vec<usize> = std::iter::once(0)
-        .chain(hole_indices.iter().copied())
-        .collect();
-    ring_offsets.push(flat_coords.len() / 2);
-
-    let mut new_flat: Vec<f64> = Vec::with_capacity(flat_coords.len());
-    let mut new_holes: Vec<usize> = Vec::with_capacity(hole_indices.len());
-    let mut index_map: Vec<usize> = Vec::with_capacity(flat_coords.len() / 2);
-
-    for ring_idx in 0..ring_offsets.len() - 1 {
-        let start_vertex = ring_offsets[ring_idx];
-        let end_vertex = ring_offsets[ring_idx + 1];
-        if ring_idx > 0 {
-            new_holes.push(new_flat.len() / 2);
-        }
-
-        let ring_start_in_new_flat = new_flat.len();
-        for orig_idx in start_vertex..end_vertex {
-            let x = flat_coords[orig_idx * 2];
-            let y = flat_coords[orig_idx * 2 + 1];
-            if new_flat.len() >= ring_start_in_new_flat + 2 {
-                if let Some(&[px, py]) = new_flat.last_chunk::<2>() {
-                    if px == x && py == y {
-                        continue;
-                    }
-                }
-            }
-
-            new_flat.push(x);
-            new_flat.push(y);
-            index_map.push(orig_idx);
-        }
-    }
-
-    (new_flat, new_holes, index_map)
 }
 
 /// Writes a `CityJSON` model as a binary glTF file.
@@ -897,62 +852,35 @@ impl MeshCollector {
     }
 
     fn add_model(&mut self, model: &CityModel) -> Result<()> {
-        for (object_id, cityobject) in model.cityobjects().iter() {
-            let Some(geometry_handles) = cityobject.geometry() else {
+        let mesh = build_triangle_mesh(model, &TriangleMeshOptions::default())?;
+        for object in mesh.objects {
+            let Some(cityobject) = model.cityobjects().get(object.handle) else {
                 continue;
             };
-            let feature_type = cityobject.type_cityobject().to_string();
-            let mut feature_index = None;
-            for geometry_handle in geometry_handles {
-                let geometry = model.resolve_geometry(*geometry_handle)?;
-                let feature_index = *feature_index.get_or_insert_with(|| {
-                    let feature_index =
-                        u32::try_from(self.features.len()).expect("feature count within u32 range");
-                    self.features.push(FeatureRecord {
-                        object_id: object_id.to_string(),
-                        feature_type: feature_type.clone(),
-                        attributes: Self::collect_feature_attributes(model, cityobject),
-                    });
-                    feature_index
-                });
-                match geometry.geometry().type_geometry() {
-                    GeometryType::MultiSurface | GeometryType::CompositeSurface => {
-                        let Some(boundary) = geometry.geometry().boundaries() else {
-                            continue;
-                        };
-                        for surface in boundary.to_nested_multi_or_composite_surface()? {
-                            self.add_surface(&feature_type, feature_index, &surface, model)?;
-                        }
-                    }
-                    GeometryType::Solid => {
-                        let Some(boundary) = geometry.geometry().boundaries() else {
-                            continue;
-                        };
-                        for shell in boundary.to_nested_solid()? {
-                            for surface in shell {
-                                self.add_surface(&feature_type, feature_index, &surface, model)?;
-                            }
-                        }
-                    }
-                    GeometryType::MultiSolid | GeometryType::CompositeSolid => {
-                        let Some(boundary) = geometry.geometry().boundaries() else {
-                            continue;
-                        };
-                        for solid in boundary.to_nested_multi_or_composite_solid()? {
-                            for shell in solid {
-                                for surface in shell {
-                                    self.add_surface(
-                                        &feature_type,
-                                        feature_index,
-                                        &surface,
-                                        model,
-                                    )?;
-                                }
-                            }
-                        }
-                    }
-                    _ => {}
-                }
+            let feature_index =
+                u32::try_from(self.features.len()).expect("feature count within u32 range");
+            self.features.push(FeatureRecord {
+                object_id: object.object_id,
+                feature_type: object.feature_type.clone(),
+                attributes: Self::collect_feature_attributes(model, cityobject),
+            });
+            let primitive = self
+                .primitives
+                .entry(object.feature_type.clone())
+                .or_default();
+            for triangle in object.triangles {
+                let local_positions = triangle
+                    .source_positions
+                    .map(|position| self.coordinate_transform.transform_position(position))
+                    .into_iter()
+                    .collect::<Result<Vec<_>>>()?;
+                primitive.add_triangle(
+                    feature_index,
+                    triangle.source_positions,
+                    [local_positions[0], local_positions[1], local_positions[2]],
+                    Self::compute_face_normal,
+                    self.smooth_normals,
+                );
             }
         }
 
@@ -961,124 +889,6 @@ impl MeshCollector {
 
     fn finish(self) -> Result<ProcessedScene> {
         ProcessedScene::from_collector(self)
-    }
-
-    fn add_surface(
-        &mut self,
-        feature_type: &str,
-        feature_id: u32,
-        surface: &[Vec<u32>],
-        model: &CityModel,
-    ) -> Result<()> {
-        if surface.is_empty() {
-            return Ok(());
-        }
-        let exterior = &surface[0];
-        if exterior.len() < 3 {
-            return Ok(());
-        }
-
-        let mut source_positions: Vec<[f64; 3]> = Vec::new();
-        let mut local_positions: Vec<[f32; 3]> = Vec::new();
-        let mut flat_coords: Vec<f64> = Vec::new();
-        let mut hole_indices: Vec<usize> = Vec::new();
-        let mut vertex_count = 0usize;
-
-        for (ring_idx, ring) in surface.iter().enumerate() {
-            if ring.len() < 3 {
-                continue;
-            }
-            if ring_idx > 0 {
-                hole_indices.push(vertex_count);
-            }
-
-            for &vertex_id in ring {
-                let vertex = model
-                    .get_vertex(VertexIndex::new(vertex_id))
-                    .ok_or_else(|| anyhow::anyhow!("missing vertex {vertex_id}"))?;
-                let source_position = vertex.to_array();
-                let local_position = self
-                    .coordinate_transform
-                    .transform_position(source_position)?;
-                source_positions.push(source_position);
-                local_positions.push(local_position);
-                vertex_count += 1;
-            }
-        }
-
-        if local_positions.len() < 3 {
-            return Ok(());
-        }
-
-        if surface.len() == 1 && exterior.len() == 3 {
-            let primitive = self.primitives.entry(feature_type.to_string()).or_default();
-            let source_triangle = [
-                source_positions[0],
-                source_positions[1],
-                source_positions[2],
-            ];
-            let local_triangle = [local_positions[0], local_positions[1], local_positions[2]];
-            primitive.add_triangle(
-                feature_id,
-                source_triangle,
-                local_triangle,
-                Self::compute_face_normal,
-                self.smooth_normals,
-            );
-            return Ok(());
-        }
-
-        let drop_axis = Self::find_projection_axis(&local_positions[..exterior.len()]);
-        for pos in &local_positions {
-            match drop_axis {
-                0 => {
-                    flat_coords.push(f64::from(pos[1]));
-                    flat_coords.push(f64::from(pos[2]));
-                }
-                1 => {
-                    flat_coords.push(f64::from(pos[0]));
-                    flat_coords.push(f64::from(pos[2]));
-                }
-                _ => {
-                    flat_coords.push(f64::from(pos[0]));
-                    flat_coords.push(f64::from(pos[1]));
-                }
-            }
-        }
-
-        let (flat_coords, hole_indices, source_index_map) =
-            dedupe_polygon_rings(&flat_coords, &hole_indices);
-        let triangulated =
-            earcut(&flat_coords, &hole_indices, 2).context("Failed to triangulate surface")?;
-        if triangulated.len() < 3 {
-            return Ok(());
-        }
-
-        let primitive = self.primitives.entry(feature_type.to_string()).or_default();
-        for tri in triangulated.chunks_exact(3) {
-            let orig0 = source_index_map[tri[0]];
-            let orig1 = source_index_map[tri[1]];
-            let orig2 = source_index_map[tri[2]];
-            let source_triangle = [
-                source_positions[orig0],
-                source_positions[orig1],
-                source_positions[orig2],
-            ];
-            let local_triangle = [
-                local_positions[orig0],
-                local_positions[orig1],
-                local_positions[orig2],
-            ];
-            primitive.add_triangle(
-                feature_id,
-                source_triangle,
-                local_triangle,
-                Self::compute_face_normal,
-                self.smooth_normals,
-            );
-        }
-
-        Ok(())
     }
 
     fn collect_feature_attributes(
@@ -1149,59 +959,6 @@ impl MeshCollector {
             AttributeValue::String(value) => Some(MetadataValue::String(value.clone())),
             _ => None,
         }
-    }
-
-    fn find_projection_axis(positions: &[[f32; 3]]) -> usize {
-        if let Some(normal) = Self::compute_polygon_normal(positions) {
-            return Self::dominant_axis(normal);
-        }
-
-        let mut min = [f32::INFINITY; 3];
-        let mut max = [f32::NEG_INFINITY; 3];
-        for pos in positions {
-            for (axis, coordinate) in pos.iter().enumerate() {
-                min[axis] = min[axis].min(*coordinate);
-                max[axis] = max[axis].max(*coordinate);
-            }
-        }
-
-        (0..3)
-            .min_by(|&lhs, &rhs| {
-                (max[lhs] - min[lhs])
-                    .partial_cmp(&(max[rhs] - min[rhs]))
-                    .unwrap()
-            })
-            .unwrap_or(2)
-    }
-
-    fn compute_polygon_normal(positions: &[[f32; 3]]) -> Option<[f32; 3]> {
-        if positions.len() < 3 {
-            return None;
-        }
-
-        let mut normal = [0.0_f32; 3];
-        for (current, next) in positions
-            .iter()
-            .zip(positions.iter().cycle().skip(1))
-            .take(positions.len())
-        {
-            normal[0] += (current[1] - next[1]) * (current[2] + next[2]);
-            normal[1] += (current[2] - next[2]) * (current[0] + next[0]);
-            normal[2] += (current[0] - next[0]) * (current[1] + next[1]);
-        }
-
-        let length = (normal[0] * normal[0] + normal[1] * normal[1] + normal[2] * normal[2]).sqrt();
-        if length > f32::EPSILON {
-            Some([normal[0] / length, normal[1] / length, normal[2] / length])
-        } else {
-            None
-        }
-    }
-
-    fn dominant_axis(normal: [f32; 3]) -> usize {
-        (0..3)
-            .max_by(|&lhs, &rhs| normal[lhs].abs().partial_cmp(&normal[rhs].abs()).unwrap())
-            .unwrap_or(2)
     }
 
     fn compute_face_normal(p0: [f32; 3], p1: [f32; 3], p2: [f32; 3]) -> [f32; 3] {

--- a/cityjson-convert/src/lib.rs
+++ b/cityjson-convert/src/lib.rs
@@ -11,6 +11,9 @@
 )]
 
 pub mod gltf_writer;
+pub mod obj_writer;
+#[path = "triangle-mesh.rs"]
+mod triangle_mesh;
 
 use std::collections::BTreeMap;
 use std::fs;
@@ -92,6 +95,11 @@ impl Default for ExportOptions {
     }
 }
 
+#[derive(Clone, Debug, Default)]
+pub struct ObjExportOptions {
+    pub clip_bbox: Option<[f64; 6]>,
+}
+
 /// Converts a `CityJSON` model to a GLB file.
 ///
 /// # Errors
@@ -108,6 +116,24 @@ pub fn convert_to_glb<P: AsRef<Path>>(
         fs::create_dir_all(parent)?;
     }
     gltf_writer::write_city_model_glb(model, output, options)
+}
+
+/// Converts a `CityJSON` model to a Wavefront OBJ file.
+///
+/// # Errors
+///
+/// Returns an error when the output directory cannot be created or OBJ writing
+/// fails.
+pub fn convert_to_obj<P: AsRef<Path>>(
+    model: &CityModel,
+    output: P,
+    options: &ObjExportOptions,
+) -> Result<()> {
+    let output = output.as_ref();
+    if let Some(parent) = output.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    obj_writer::write_city_model_obj(model, output, options)
 }
 
 /// Converts a `CityJSON` model to a `CityJSON` file.

--- a/cityjson-convert/src/main.rs
+++ b/cityjson-convert/src/main.rs
@@ -4,8 +4,9 @@ use std::path::PathBuf;
 
 use anyhow::{bail, Context};
 use cityjson_convert::{
-    convert_to_cityjson, convert_to_cityjsonseq, convert_to_glb, CityJsonSeqExportOptions,
-    ExportOptions, GeometryPlacement, JsonExportOptions,
+    convert_to_cityjson, convert_to_cityjsonseq, convert_to_glb, convert_to_obj,
+    CityJsonSeqExportOptions, ExportOptions, GeometryPlacement, JsonExportOptions,
+    ObjExportOptions,
 };
 use cityjson_lib::json;
 use clap::{Parser, ValueEnum};
@@ -16,6 +17,7 @@ use log::info;
 enum OutputFormat {
     #[default]
     Glb,
+    Obj,
     Cityjson,
     Cityjsonseq,
 }
@@ -70,6 +72,12 @@ fn main() -> anyhow::Result<()> {
             info!("Converting to GLB");
             convert_to_glb(&model, &cli.output, &options)?;
             info!("GLB written to {}", cli.output.display());
+        }
+        OutputFormat::Obj => {
+            let model = json::from_file(&cli.input)?;
+            info!("Converting to OBJ");
+            convert_to_obj(&model, &cli.output, &ObjExportOptions::default())?;
+            info!("OBJ written to {}", cli.output.display());
         }
         OutputFormat::Cityjson => {
             let model = json::from_file(&cli.input)?;

--- a/cityjson-convert/src/obj_writer.rs
+++ b/cityjson-convert/src/obj_writer.rs
@@ -1,0 +1,89 @@
+use std::fs::File;
+use std::io::{BufWriter, Write};
+use std::path::Path;
+
+use anyhow::Result;
+use cityjson_lib::CityModel;
+use log::debug;
+
+use crate::triangle_mesh::{build_triangle_mesh, TriangleMeshOptions};
+use crate::ObjExportOptions;
+
+pub fn write_city_model_obj<P: AsRef<Path>>(
+    model: &CityModel,
+    output_path: P,
+    options: &ObjExportOptions,
+) -> Result<()> {
+    let mesh = build_triangle_mesh(
+        model,
+        &TriangleMeshOptions {
+            clip_bbox: options.clip_bbox,
+            clip_geographic_region: None,
+        },
+    )?;
+
+    let file = File::create(output_path.as_ref())?;
+    let mut writer = BufWriter::new(file);
+    let mut next_index = 1_u64;
+    let mut vertex_count = 0_u64;
+    let mut face_count = 0_u64;
+
+    for object in mesh.objects {
+        if object.triangles.is_empty() {
+            continue;
+        }
+        writeln!(writer, "o {}", sanitize_object_name(&object.object_id))?;
+        for triangle in object.triangles {
+            for position in triangle.source_positions {
+                writeln!(writer, "v {} {} {}", position[0], position[1], position[2])?;
+            }
+            writeln!(
+                writer,
+                "f {} {} {}",
+                next_index,
+                next_index + 1,
+                next_index + 2
+            )?;
+            next_index += 3;
+            vertex_count += 3;
+            face_count += 1;
+        }
+    }
+
+    writer.flush()?;
+    debug!(
+        "OBJ Summary: {} vertices and {} faces written to {}",
+        vertex_count,
+        face_count,
+        output_path.as_ref().display()
+    );
+    Ok(())
+}
+
+fn sanitize_object_name(value: &str) -> String {
+    let sanitized = value
+        .chars()
+        .map(|ch| {
+            if ch.is_whitespace() || ch.is_control() {
+                '_'
+            } else {
+                ch
+            }
+        })
+        .collect::<String>();
+    if sanitized.is_empty() {
+        "_".to_string()
+    } else {
+        sanitized
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::sanitize_object_name;
+
+    #[test]
+    fn sanitize_replaces_whitespace_and_control_characters() {
+        assert_eq!(sanitize_object_name("a b\tc\n"), "a_b_c_");
+    }
+}

--- a/cityjson-convert/src/obj_writer.rs
+++ b/cityjson-convert/src/obj_writer.rs
@@ -9,6 +9,12 @@ use log::debug;
 use crate::triangle_mesh::{build_triangle_mesh, TriangleMeshOptions};
 use crate::ObjExportOptions;
 
+/// Writes a `CityJSON` model as a Wavefront OBJ file.
+///
+/// # Errors
+///
+/// Returns an error when model geometry cannot be triangulated or clipped, or
+/// when the OBJ file cannot be created or written.
 pub fn write_city_model_obj<P: AsRef<Path>>(
     model: &CityModel,
     output_path: P,

--- a/cityjson-convert/src/triangle-mesh.rs
+++ b/cityjson-convert/src/triangle-mesh.rs
@@ -180,19 +180,17 @@ fn add_surface(
     }
 
     if surface.len() == 1 && exterior.len() == 3 {
-        push_triangle(
-            triangles,
-            [
-                source_positions[0],
-                source_positions[1],
-                source_positions[2],
-            ],
-            clip_volume,
-        )?;
+        let source_triangle = [
+            source_positions[0],
+            source_positions[1],
+            source_positions[2],
+        ];
+        push_triangle(triangles, source_triangle, clip_volume)?;
         return Ok(());
     }
 
-    let drop_axis = find_projection_axis(&source_positions[..exterior.len()]);
+    let (drop_axis, surface_normal) =
+        projection_axis_and_normal(&source_positions[..exterior.len()]);
     for pos in &source_positions {
         match drop_axis {
             0 => {
@@ -217,19 +215,22 @@ fn add_surface(
     if triangulated.len() < 3 {
         return Ok(());
     }
+    // earcutr normalizes the outer ring to positive 2D winding. Map that
+    // known 2D orientation back to the selected 3D projection once per surface.
+    let reverse_earcut_winding = should_reverse_earcut_winding(drop_axis, surface_normal);
     for tri in triangulated.chunks_exact(3) {
         let orig0 = source_index_map[tri[0]];
         let orig1 = source_index_map[tri[1]];
         let orig2 = source_index_map[tri[2]];
-        push_triangle(
-            triangles,
-            [
-                source_positions[orig0],
-                source_positions[orig1],
-                source_positions[orig2],
-            ],
-            clip_volume,
-        )?;
+        let mut source_triangle = [
+            source_positions[orig0],
+            source_positions[orig1],
+            source_positions[orig2],
+        ];
+        if reverse_earcut_winding {
+            source_triangle.swap(1, 2);
+        }
+        push_triangle(triangles, source_triangle, clip_volume)?;
     }
 
     Ok(())
@@ -278,6 +279,17 @@ fn dedupe_polygon_rings(
     }
 
     (new_flat, new_holes, index_map)
+}
+
+fn should_reverse_earcut_winding(drop_axis: usize, surface_normal: Option<[f64; 3]>) -> bool {
+    let Some(surface_normal) = surface_normal else {
+        return false;
+    };
+    let positive_projected_winding_axis = match drop_axis {
+        1 => -1.0,
+        _ => 1.0,
+    };
+    positive_projected_winding_axis * surface_normal[drop_axis] < 0.0
 }
 
 fn push_triangle(
@@ -557,9 +569,10 @@ fn canonical_epsg_crs(value: &str) -> Result<String> {
     Ok(format!("EPSG:{parsed}"))
 }
 
-fn find_projection_axis(positions: &[[f64; 3]]) -> usize {
-    if let Some(normal) = compute_polygon_normal(positions) {
-        return dominant_axis(normal);
+fn projection_axis_and_normal(positions: &[[f64; 3]]) -> (usize, Option<[f64; 3]>) {
+    let normal = compute_polygon_normal(positions);
+    if let Some(normal) = normal {
+        return (dominant_axis(normal), Some(normal));
     }
 
     let mut min = [f64::INFINITY; 3];
@@ -571,13 +584,14 @@ fn find_projection_axis(positions: &[[f64; 3]]) -> usize {
         }
     }
 
-    (0..3)
+    let drop_axis = (0..3)
         .min_by(|&lhs, &rhs| {
             (max[lhs] - min[lhs])
                 .partial_cmp(&(max[rhs] - min[rhs]))
                 .unwrap()
         })
-        .unwrap_or(2)
+        .unwrap_or(2);
+    (drop_axis, None)
 }
 
 fn compute_polygon_normal(positions: &[[f64; 3]]) -> Option<[f64; 3]> {
@@ -606,7 +620,7 @@ fn dominant_axis(normal: [f64; 3]) -> usize {
         .unwrap_or(2)
 }
 
-fn is_degenerate_source_triangle(points: [[f64; 3]; 3]) -> bool {
+fn triangle_normal(points: [[f64; 3]; 3]) -> [f64; 3] {
     let u = [
         points[1][0] - points[0][0],
         points[1][1] - points[0][1],
@@ -617,11 +631,15 @@ fn is_degenerate_source_triangle(points: [[f64; 3]; 3]) -> bool {
         points[2][1] - points[0][1],
         points[2][2] - points[0][2],
     ];
-    let cross = [
+    [
         u[1] * v[2] - u[2] * v[1],
         u[2] * v[0] - u[0] * v[2],
         u[0] * v[1] - u[1] * v[0],
-    ];
+    ]
+}
+
+fn is_degenerate_source_triangle(points: [[f64; 3]; 3]) -> bool {
+    let cross = triangle_normal(points);
     let area_sq = cross[0] * cross[0] + cross[1] * cross[1] + cross[2] * cross[2];
     area_sq <= 1.0e-18
 }

--- a/cityjson-convert/src/triangle-mesh.rs
+++ b/cityjson-convert/src/triangle-mesh.rs
@@ -1,0 +1,627 @@
+use anyhow::{bail, Context, Result};
+use cityjson_lib::cityjson_types::prelude::CityObjectHandle;
+use cityjson_lib::cityjson_types::v2_0::{GeometryType, VertexIndex};
+use cityjson_lib::ops::Transformer;
+use cityjson_lib::CityModel;
+use earcutr::earcut;
+
+use crate::GeographicClipRegion;
+
+const CLIP_PLANE_EPSILON: f64 = 1.0e-12;
+const GEOGRAPHIC_CLIP_INTERSECTION_ITERATIONS: usize = 64;
+
+#[derive(Clone, Debug, Default)]
+pub struct TriangleMeshOptions {
+    pub clip_bbox: Option<[f64; 6]>,
+    pub clip_geographic_region: Option<GeographicClipRegion>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct TriangleMesh {
+    pub objects: Vec<ObjectMesh>,
+}
+
+#[derive(Clone, Debug)]
+pub struct ObjectMesh {
+    pub handle: CityObjectHandle,
+    pub object_id: String,
+    pub feature_type: String,
+    pub triangles: Vec<SourceTriangle>,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct SourceTriangle {
+    pub source_positions: [[f64; 3]; 3],
+}
+
+#[derive(Clone, Copy, Debug)]
+struct ClipVertex {
+    source_position: [f64; 3],
+    clip_position: [f64; 3],
+}
+
+struct GeographicClipVolume {
+    transformer: Option<CachedProjTransform>,
+    west: f64,
+    south: f64,
+    east: f64,
+    north: f64,
+}
+
+enum ClipVolume {
+    SourceBbox([f64; 6]),
+    GeographicRegion(GeographicClipVolume),
+}
+
+#[derive(Clone, Debug)]
+struct CachedProjTransform {
+    transformer: Transformer,
+}
+
+impl CachedProjTransform {
+    fn new(source_crs: &str, target_crs: &'static str) -> Result<Self> {
+        let transformer = cityjson_lib::ops::transformer(source_crs, target_crs)
+            .with_context(|| format!("failed to create {source_crs} to {target_crs} transform"))?;
+        Ok(Self { transformer })
+    }
+
+    fn convert(&self, point: [f64; 3]) -> Result<[f64; 3]> {
+        self.transformer.transform(point).map_err(Into::into)
+    }
+}
+
+pub fn build_triangle_mesh(
+    model: &CityModel,
+    options: &TriangleMeshOptions,
+) -> Result<TriangleMesh> {
+    let clip_volume = ClipVolume::from_options(options)?;
+    let mut objects = Vec::new();
+
+    for (handle, cityobject) in model.cityobjects().iter() {
+        let Some(geometry_handles) = cityobject.geometry() else {
+            continue;
+        };
+
+        let mut object_mesh = ObjectMesh {
+            handle,
+            object_id: cityobject.id().to_string(),
+            feature_type: cityobject.type_cityobject().to_string(),
+            triangles: Vec::new(),
+        };
+
+        for geometry_handle in geometry_handles {
+            let geometry = model.resolve_geometry(*geometry_handle)?;
+            let Some(boundary) = geometry.geometry().boundaries() else {
+                continue;
+            };
+            match geometry.geometry().type_geometry() {
+                GeometryType::MultiSurface | GeometryType::CompositeSurface => {
+                    for surface in boundary.to_nested_multi_or_composite_surface()? {
+                        add_surface(
+                            &mut object_mesh.triangles,
+                            &surface,
+                            model,
+                            clip_volume.as_ref(),
+                        )?;
+                    }
+                }
+                GeometryType::Solid => {
+                    for shell in boundary.to_nested_solid()? {
+                        for surface in shell {
+                            add_surface(
+                                &mut object_mesh.triangles,
+                                &surface,
+                                model,
+                                clip_volume.as_ref(),
+                            )?;
+                        }
+                    }
+                }
+                GeometryType::MultiSolid | GeometryType::CompositeSolid => {
+                    for solid in boundary.to_nested_multi_or_composite_solid()? {
+                        for shell in solid {
+                            for surface in shell {
+                                add_surface(
+                                    &mut object_mesh.triangles,
+                                    &surface,
+                                    model,
+                                    clip_volume.as_ref(),
+                                )?;
+                            }
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        if !object_mesh.triangles.is_empty() {
+            objects.push(object_mesh);
+        }
+    }
+
+    Ok(TriangleMesh { objects })
+}
+
+fn add_surface(
+    triangles: &mut Vec<SourceTriangle>,
+    surface: &[Vec<u32>],
+    model: &CityModel,
+    clip_volume: Option<&ClipVolume>,
+) -> Result<()> {
+    if surface.is_empty() || surface[0].len() < 3 {
+        return Ok(());
+    }
+
+    let exterior = &surface[0];
+    let mut source_positions = Vec::new();
+    let mut flat_coords = Vec::new();
+    let mut hole_indices = Vec::new();
+    let mut vertex_count = 0usize;
+
+    for (ring_idx, ring) in surface.iter().enumerate() {
+        if ring.len() < 3 {
+            continue;
+        }
+        if ring_idx > 0 {
+            hole_indices.push(vertex_count);
+        }
+        for &vertex_id in ring {
+            let vertex = model
+                .get_vertex(VertexIndex::new(vertex_id))
+                .ok_or_else(|| anyhow::anyhow!("missing vertex {vertex_id}"))?;
+            source_positions.push(vertex.to_array());
+            vertex_count += 1;
+        }
+    }
+
+    if source_positions.len() < 3 {
+        return Ok(());
+    }
+
+    if surface.len() == 1 && exterior.len() == 3 {
+        push_triangle(
+            triangles,
+            [
+                source_positions[0],
+                source_positions[1],
+                source_positions[2],
+            ],
+            clip_volume,
+        )?;
+        return Ok(());
+    }
+
+    let drop_axis = find_projection_axis(&source_positions[..exterior.len()]);
+    for pos in &source_positions {
+        match drop_axis {
+            0 => {
+                flat_coords.push(pos[1]);
+                flat_coords.push(pos[2]);
+            }
+            1 => {
+                flat_coords.push(pos[0]);
+                flat_coords.push(pos[2]);
+            }
+            _ => {
+                flat_coords.push(pos[0]);
+                flat_coords.push(pos[1]);
+            }
+        }
+    }
+
+    let (flat_coords, hole_indices, source_index_map) =
+        dedupe_polygon_rings(&flat_coords, &hole_indices);
+    let triangulated =
+        earcut(&flat_coords, &hole_indices, 2).context("Failed to triangulate surface")?;
+    if triangulated.len() < 3 {
+        return Ok(());
+    }
+    for tri in triangulated.chunks_exact(3) {
+        let orig0 = source_index_map[tri[0]];
+        let orig1 = source_index_map[tri[1]];
+        let orig2 = source_index_map[tri[2]];
+        push_triangle(
+            triangles,
+            [
+                source_positions[orig0],
+                source_positions[orig1],
+                source_positions[orig2],
+            ],
+            clip_volume,
+        )?;
+    }
+
+    Ok(())
+}
+
+/// Strip consecutive bit-identical vertices from each ring before
+/// triangulation. earcutr can spin forever on polygons that contain inner rings
+/// whose vertices repeat.
+#[allow(clippy::float_cmp)]
+fn dedupe_polygon_rings(
+    flat_coords: &[f64],
+    hole_indices: &[usize],
+) -> (Vec<f64>, Vec<usize>, Vec<usize>) {
+    let mut ring_offsets: Vec<usize> = std::iter::once(0)
+        .chain(hole_indices.iter().copied())
+        .collect();
+    ring_offsets.push(flat_coords.len() / 2);
+
+    let mut new_flat: Vec<f64> = Vec::with_capacity(flat_coords.len());
+    let mut new_holes: Vec<usize> = Vec::with_capacity(hole_indices.len());
+    let mut index_map: Vec<usize> = Vec::with_capacity(flat_coords.len() / 2);
+
+    for ring_idx in 0..ring_offsets.len() - 1 {
+        let start_vertex = ring_offsets[ring_idx];
+        let end_vertex = ring_offsets[ring_idx + 1];
+        if ring_idx > 0 {
+            new_holes.push(new_flat.len() / 2);
+        }
+
+        let ring_start_in_new_flat = new_flat.len();
+        for orig_idx in start_vertex..end_vertex {
+            let x = flat_coords[orig_idx * 2];
+            let y = flat_coords[orig_idx * 2 + 1];
+            if new_flat.len() >= ring_start_in_new_flat + 2 {
+                if let Some(&[px, py]) = new_flat.last_chunk::<2>() {
+                    if px == x && py == y {
+                        continue;
+                    }
+                }
+            }
+
+            new_flat.push(x);
+            new_flat.push(y);
+            index_map.push(orig_idx);
+        }
+    }
+
+    (new_flat, new_holes, index_map)
+}
+
+fn push_triangle(
+    triangles: &mut Vec<SourceTriangle>,
+    source_positions: [[f64; 3]; 3],
+    clip_volume: Option<&ClipVolume>,
+) -> Result<()> {
+    let clipped_triangles = if let Some(clip_volume) = clip_volume {
+        clip_triangle_to_volume(source_positions, clip_volume)?
+    } else {
+        vec![source_positions]
+    };
+
+    for triangle in clipped_triangles {
+        if !is_degenerate_source_triangle(triangle) {
+            triangles.push(SourceTriangle {
+                source_positions: triangle,
+            });
+        }
+    }
+    Ok(())
+}
+
+impl ClipVolume {
+    fn from_options(options: &TriangleMeshOptions) -> Result<Option<Self>> {
+        if let Some(region) = &options.clip_geographic_region {
+            return Self::geographic_region(region).map(Some);
+        }
+        Ok(options.clip_bbox.map(Self::SourceBbox))
+    }
+
+    fn geographic_region(region: &GeographicClipRegion) -> Result<Self> {
+        let source_crs = canonical_epsg_crs(&region.source_crs)?;
+        let transformer = if source_crs == "EPSG:4979" {
+            None
+        } else {
+            Some(CachedProjTransform::new(&source_crs, "EPSG:4979")?)
+        };
+        Ok(Self::GeographicRegion(GeographicClipVolume {
+            transformer,
+            west: region.west,
+            south: region.south,
+            east: region.east,
+            north: region.north,
+        }))
+    }
+
+    fn clip_position(&self, source_position: [f64; 3]) -> Result<[f64; 3]> {
+        match self {
+            Self::SourceBbox(_) => Ok(source_position),
+            Self::GeographicRegion(region) => {
+                let geographic = if let Some(transformer) = &region.transformer {
+                    transformer
+                        .convert(source_position)
+                        .context("failed to project position to EPSG:4979 for clipping")?
+                } else {
+                    source_position
+                };
+                Ok(geographic)
+            }
+        }
+    }
+
+    fn planes(&self) -> ([(usize, f64, bool); 6], usize) {
+        match self {
+            Self::SourceBbox(bbox) => (
+                [
+                    (0, bbox[0], false),
+                    (0, bbox[3], true),
+                    (1, bbox[1], false),
+                    (1, bbox[4], true),
+                    (2, bbox[2], false),
+                    (2, bbox[5], true),
+                ],
+                6,
+            ),
+            Self::GeographicRegion(region) => (
+                [
+                    (0, region.west, false),
+                    (0, region.east, true),
+                    (1, region.south, false),
+                    (1, region.north, true),
+                    (0, 0.0, true),
+                    (0, 0.0, true),
+                ],
+                4,
+            ),
+        }
+    }
+
+    fn intersect_edge(
+        &self,
+        start: ClipVertex,
+        end: ClipVertex,
+        axis: usize,
+        boundary: f64,
+    ) -> Result<Option<ClipVertex>> {
+        match self {
+            Self::SourceBbox(_) => self.intersect_edge_linear(start, end, axis, boundary),
+            Self::GeographicRegion(_) => self.intersect_edge_geographic(start, end, axis, boundary),
+        }
+    }
+
+    fn intersect_edge_linear(
+        &self,
+        start: ClipVertex,
+        end: ClipVertex,
+        axis: usize,
+        boundary: f64,
+    ) -> Result<Option<ClipVertex>> {
+        let delta = end.clip_position[axis] - start.clip_position[axis];
+        if delta.abs() <= CLIP_PLANE_EPSILON {
+            return Ok(None);
+        }
+        let t = (boundary - start.clip_position[axis]) / delta;
+        self.interpolate_clip_vertex(start, end, t).map(Some)
+    }
+
+    fn intersect_edge_geographic(
+        &self,
+        start: ClipVertex,
+        end: ClipVertex,
+        axis: usize,
+        boundary: f64,
+    ) -> Result<Option<ClipVertex>> {
+        let mut low_t = 0.0;
+        let mut high_t = 1.0;
+        let mut low_distance = start.clip_position[axis] - boundary;
+        let high_distance = end.clip_position[axis] - boundary;
+
+        if low_distance.abs() <= CLIP_PLANE_EPSILON {
+            return Ok(Some(start));
+        }
+        if high_distance.abs() <= CLIP_PLANE_EPSILON {
+            return Ok(Some(end));
+        }
+        if low_distance.signum() == high_distance.signum() {
+            bail!(
+                "geographic clip edge does not bracket boundary on axis {axis}: {low_distance} to {high_distance}"
+            );
+        }
+
+        for _ in 0..GEOGRAPHIC_CLIP_INTERSECTION_ITERATIONS {
+            let mid_t = f64::midpoint(low_t, high_t);
+            let midpoint = self.interpolate_clip_vertex(start, end, mid_t)?;
+            let mid_distance = midpoint.clip_position[axis] - boundary;
+            if mid_distance.abs() <= CLIP_PLANE_EPSILON || (high_t - low_t).abs() <= f64::EPSILON {
+                return Ok(Some(midpoint));
+            }
+            if low_distance.signum() == mid_distance.signum() {
+                low_t = mid_t;
+                low_distance = mid_distance;
+            } else {
+                high_t = mid_t;
+            }
+        }
+
+        let t = f64::midpoint(low_t, high_t);
+        self.interpolate_clip_vertex(start, end, t).map(Some)
+    }
+
+    fn interpolate_clip_vertex(
+        &self,
+        start: ClipVertex,
+        end: ClipVertex,
+        t: f64,
+    ) -> Result<ClipVertex> {
+        let source_position = [
+            start.source_position[0] + (end.source_position[0] - start.source_position[0]) * t,
+            start.source_position[1] + (end.source_position[1] - start.source_position[1]) * t,
+            start.source_position[2] + (end.source_position[2] - start.source_position[2]) * t,
+        ];
+        Ok(ClipVertex {
+            source_position,
+            clip_position: self.clip_position(source_position)?,
+        })
+    }
+}
+
+fn clip_triangle_to_volume(
+    triangle: [[f64; 3]; 3],
+    clip_volume: &ClipVolume,
+) -> Result<Vec<[[f64; 3]; 3]>> {
+    let mut polygon = vec![
+        ClipVertex {
+            source_position: triangle[0],
+            clip_position: clip_volume.clip_position(triangle[0])?,
+        },
+        ClipVertex {
+            source_position: triangle[1],
+            clip_position: clip_volume.clip_position(triangle[1])?,
+        },
+        ClipVertex {
+            source_position: triangle[2],
+            clip_position: clip_volume.clip_position(triangle[2])?,
+        },
+    ];
+
+    let (planes, plane_count) = clip_volume.planes();
+    for (axis, boundary, keep_less_equal) in planes.into_iter().take(plane_count) {
+        polygon =
+            clip_polygon_against_plane(polygon, clip_volume, axis, boundary, keep_less_equal)?;
+        if polygon.len() < 3 {
+            return Ok(Vec::new());
+        }
+    }
+
+    let mut triangles = Vec::with_capacity(polygon.len().saturating_sub(2));
+    for index in 1..polygon.len() - 1 {
+        triangles.push([
+            polygon[0].source_position,
+            polygon[index].source_position,
+            polygon[index + 1].source_position,
+        ]);
+    }
+    Ok(triangles)
+}
+
+fn clip_polygon_against_plane(
+    polygon: Vec<ClipVertex>,
+    clip_volume: &ClipVolume,
+    axis: usize,
+    boundary: f64,
+    keep_less_equal: bool,
+) -> Result<Vec<ClipVertex>> {
+    if polygon.is_empty() {
+        return Ok(polygon);
+    }
+
+    let mut clipped = Vec::new();
+    for index in 0..polygon.len() {
+        let current = polygon[index];
+        let next = polygon[(index + 1) % polygon.len()];
+        let current_distance = current.clip_position[axis] - boundary;
+        let next_distance = next.clip_position[axis] - boundary;
+        let current_inside = if keep_less_equal {
+            current_distance <= CLIP_PLANE_EPSILON
+        } else {
+            current_distance >= -CLIP_PLANE_EPSILON
+        };
+        let next_inside = if keep_less_equal {
+            next_distance <= CLIP_PLANE_EPSILON
+        } else {
+            next_distance >= -CLIP_PLANE_EPSILON
+        };
+
+        if current_inside && next_inside {
+            clipped.push(next);
+            continue;
+        }
+        if current_inside != next_inside {
+            if let Some(intersection) = clip_volume.intersect_edge(current, next, axis, boundary)? {
+                clipped.push(intersection);
+            }
+        }
+        if !current_inside && next_inside {
+            clipped.push(next);
+        }
+    }
+
+    Ok(clipped)
+}
+
+fn canonical_epsg_crs(value: &str) -> Result<String> {
+    if let Some(code) = value.strip_prefix("EPSG:") {
+        let parsed = code.parse::<u32>().context("invalid EPSG code")?;
+        return Ok(format!("EPSG:{parsed}"));
+    }
+
+    let code = value
+        .rsplit(['/', ':'])
+        .find(|part| !part.is_empty())
+        .ok_or_else(|| anyhow::anyhow!("could not extract EPSG code from {value}"))?;
+    let parsed = code
+        .parse::<u32>()
+        .with_context(|| format!("invalid EPSG code in {value}"))?;
+    Ok(format!("EPSG:{parsed}"))
+}
+
+fn find_projection_axis(positions: &[[f64; 3]]) -> usize {
+    if let Some(normal) = compute_polygon_normal(positions) {
+        return dominant_axis(normal);
+    }
+
+    let mut min = [f64::INFINITY; 3];
+    let mut max = [f64::NEG_INFINITY; 3];
+    for pos in positions {
+        for (axis, coordinate) in pos.iter().enumerate() {
+            min[axis] = min[axis].min(*coordinate);
+            max[axis] = max[axis].max(*coordinate);
+        }
+    }
+
+    (0..3)
+        .min_by(|&lhs, &rhs| {
+            (max[lhs] - min[lhs])
+                .partial_cmp(&(max[rhs] - min[rhs]))
+                .unwrap()
+        })
+        .unwrap_or(2)
+}
+
+fn compute_polygon_normal(positions: &[[f64; 3]]) -> Option<[f64; 3]> {
+    if positions.len() < 3 {
+        return None;
+    }
+
+    let mut normal = [0.0_f64; 3];
+    for (current, next) in positions
+        .iter()
+        .zip(positions.iter().cycle().skip(1))
+        .take(positions.len())
+    {
+        normal[0] += (current[1] - next[1]) * (current[2] + next[2]);
+        normal[1] += (current[2] - next[2]) * (current[0] + next[0]);
+        normal[2] += (current[0] - next[0]) * (current[1] + next[1]);
+    }
+
+    let length = (normal[0] * normal[0] + normal[1] * normal[1] + normal[2] * normal[2]).sqrt();
+    (length > f64::EPSILON).then_some([normal[0] / length, normal[1] / length, normal[2] / length])
+}
+
+fn dominant_axis(normal: [f64; 3]) -> usize {
+    (0..3)
+        .max_by(|&lhs, &rhs| normal[lhs].abs().partial_cmp(&normal[rhs].abs()).unwrap())
+        .unwrap_or(2)
+}
+
+fn is_degenerate_source_triangle(points: [[f64; 3]; 3]) -> bool {
+    let u = [
+        points[1][0] - points[0][0],
+        points[1][1] - points[0][1],
+        points[1][2] - points[0][2],
+    ];
+    let v = [
+        points[2][0] - points[0][0],
+        points[2][1] - points[0][1],
+        points[2][2] - points[0][2],
+    ];
+    let cross = [
+        u[1] * v[2] - u[2] * v[1],
+        u[2] * v[0] - u[0] * v[2],
+        u[0] * v[1] - u[1] * v[0],
+    ];
+    let area_sq = cross[0] * cross[0] + cross[1] * cross[1] + cross[2] * cross[2];
+    area_sq <= 1.0e-18
+}

--- a/cityjson-convert/tests/gltf_writer_geometry.rs
+++ b/cityjson-convert/tests/gltf_writer_geometry.rs
@@ -4,8 +4,9 @@ use std::path::PathBuf;
 use std::process::Command;
 
 use cityjson_convert::{
-    convert_to_cityjson, convert_to_cityjsonseq, convert_to_glb, CityJsonSeqExportOptions,
-    ExportOptions, GeographicClipRegion, GeometryPlacement, JsonExportOptions,
+    convert_to_cityjson, convert_to_cityjsonseq, convert_to_glb, convert_to_obj,
+    CityJsonSeqExportOptions, ExportOptions, GeographicClipRegion, GeometryPlacement,
+    JsonExportOptions, ObjExportOptions,
 };
 use cityjson_lib::json;
 use serde_json::Value;
@@ -48,6 +49,123 @@ fn read_json_lines(path: &PathBuf) -> Vec<Value> {
         .filter(|line| !line.trim().is_empty())
         .map(|line| serde_json::from_str(line).expect("json line should parse"))
         .collect()
+}
+
+fn read_obj_lines(path: &PathBuf) -> Vec<String> {
+    fs::read_to_string(path)
+        .expect("read OBJ output")
+        .lines()
+        .map(str::to_string)
+        .collect()
+}
+
+fn inline_feature(id: &str, vertices: &str, boundaries: &str) -> Vec<u8> {
+    format!(
+        r#"{{"type":"CityJSONFeature","id":"{id}","transform":{{"scale":[1.0,1.0,1.0],"translate":[0.0,0.0,0.0]}},"CityObjects":{{"{id}":{{"type":"Building","geometry":[{{"type":"MultiSurface","lod":"1","boundaries":{boundaries}}}]}}}},"vertices":{vertices}}}"#
+    )
+    .into_bytes()
+}
+
+#[test]
+fn convert_to_obj_writes_single_triangle_in_source_coordinates() {
+    let input = inline_feature(
+        "source triangle",
+        "[[1000.5,2000.25,3.0],[1001.5,2000.25,3.0],[1000.5,2001.25,4.0]]",
+        "[[[0,1,2]]]",
+    );
+    let model = json::from_feature_slice(&input).expect("inline feature should parse");
+    let output_path = stable_output_path_with_suffix("convert_to_obj_single_triangle", "obj");
+
+    convert_to_obj(&model, &output_path, &ObjExportOptions::default())
+        .expect("OBJ conversion should succeed");
+
+    let lines = read_obj_lines(&output_path);
+    assert_eq!(lines[0], "o source_triangle");
+    assert_eq!(lines[1], "v 1000.5 2000.25 3");
+    assert_eq!(lines[2], "v 1001.5 2000.25 3");
+    assert_eq!(lines[3], "v 1000.5 2001.25 4");
+    assert_eq!(lines[4], "f 1 2 3");
+}
+
+#[test]
+fn convert_to_obj_groups_cityobjects_and_uses_global_indices() {
+    let model =
+        json::merge_feature_stream_slice(include_bytes!("data/multi_feature_types.city.jsonl"))
+            .expect("fixture should merge");
+    let output_path = stable_output_path_with_suffix("convert_to_obj_multi_object", "obj");
+
+    convert_to_obj(&model, &output_path, &ObjExportOptions::default())
+        .expect("OBJ conversion should succeed");
+
+    let lines = read_obj_lines(&output_path);
+    let object_lines = lines
+        .iter()
+        .filter(|line| line.starts_with("o "))
+        .collect::<Vec<_>>();
+    assert!(object_lines
+        .iter()
+        .any(|line| *line == "o building-feature"));
+    assert!(object_lines.iter().any(|line| *line == "o water-feature"));
+    assert!(lines.iter().any(|line| line == "f 1 2 3"));
+    assert!(lines
+        .iter()
+        .filter_map(|line| line.strip_prefix("f "))
+        .any(|face| face != "1 2 3"));
+}
+
+#[test]
+fn convert_to_obj_triangulates_polygons_and_preserves_unclipped_geometry_by_default() {
+    let input = inline_feature(
+        "quad",
+        "[[0.0,0.0,0.0],[2.0,0.0,0.0],[2.0,2.0,0.0],[0.0,2.0,0.0]]",
+        "[[[0,1,2,3]]]",
+    );
+    let model = json::from_feature_slice(&input).expect("inline feature should parse");
+    let output_path = stable_output_path_with_suffix("convert_to_obj_quad", "obj");
+
+    convert_to_obj(&model, &output_path, &ObjExportOptions::default())
+        .expect("OBJ conversion should succeed");
+
+    let lines = read_obj_lines(&output_path);
+    assert_eq!(
+        lines.iter().filter(|line| line.starts_with("f ")).count(),
+        2
+    );
+    assert!(lines.iter().any(|line| line == "v 2 2 0"));
+}
+
+#[test]
+fn convert_to_obj_can_clip_to_bbox() {
+    let input = inline_feature(
+        "clip",
+        "[[-1.0,0.0,0.0],[2.0,0.0,0.0],[0.0,2.0,0.0]]",
+        "[[[0,1,2]]]",
+    );
+    let model = json::from_feature_slice(&input).expect("inline feature should parse");
+    let output_path = stable_output_path_with_suffix("convert_to_obj_clipped", "obj");
+    let options = ObjExportOptions {
+        clip_bbox: Some([0.0, 0.0, -1.0, 1.0, 1.0, 1.0]),
+    };
+
+    convert_to_obj(&model, &output_path, &options).expect("OBJ conversion should succeed");
+
+    let lines = read_obj_lines(&output_path);
+    let vertices = lines
+        .iter()
+        .filter_map(|line| line.strip_prefix("v "))
+        .map(|line| {
+            line.split_whitespace()
+                .map(|value| value.parse::<f64>().unwrap())
+                .collect::<Vec<_>>()
+        })
+        .collect::<Vec<_>>();
+    assert!(!vertices.is_empty());
+    assert!(vertices.iter().all(|vertex| {
+        vertex[0] >= -1.0e-9
+            && vertex[0] <= 1.0 + 1.0e-9
+            && vertex[1] >= -1.0e-9
+            && vertex[1] <= 1.0 + 1.0e-9
+    }));
 }
 
 #[test]
@@ -100,9 +218,10 @@ fn convert_to_cityjsonseq_writes_header_and_features() {
 }
 
 #[test]
-fn cjconvert_can_write_cityjson_and_cityjsonseq() {
+fn cjconvert_can_write_cityjson_cityjsonseq_and_obj() {
     let cityjson_output = stable_output_path_with_suffix("cjconvert_cityjson", "city.json");
     let cityjsonseq_output = stable_output_path_with_suffix("cjconvert_cityjsonseq", "city.jsonl");
+    let obj_output = stable_output_path_with_suffix("cjconvert_obj", "obj");
     let cityjson_input = stable_output_path_with_suffix("cjconvert_input", "city.json");
     let model =
         json::merge_feature_stream_slice(include_bytes!("data/multi_feature_types.city.jsonl"))
@@ -139,6 +258,20 @@ fn cjconvert_can_write_cityjson_and_cityjsonseq() {
     let items = read_json_lines(&cityjsonseq_output);
     assert_eq!(items[0]["type"], "CityJSON");
     assert_eq!(items[1]["type"], "CityJSONFeature");
+
+    let obj_status = Command::new(env!("CARGO_BIN_EXE_cjconvert"))
+        .arg(&cityjson_input)
+        .arg("--output")
+        .arg(&obj_output)
+        .arg("--format")
+        .arg("obj")
+        .status()
+        .expect("run cjconvert obj");
+    assert!(obj_status.success());
+    let obj_lines = read_obj_lines(&obj_output);
+    assert!(obj_lines.iter().any(|line| line.starts_with("o ")));
+    assert!(obj_lines.iter().any(|line| line.starts_with("v ")));
+    assert!(obj_lines.iter().any(|line| line.starts_with("f ")));
 }
 
 #[allow(clippy::cast_possible_truncation)]

--- a/cityjson-convert/tests/gltf_writer_geometry.rs
+++ b/cityjson-convert/tests/gltf_writer_geometry.rs
@@ -59,11 +59,51 @@ fn read_obj_lines(path: &PathBuf) -> Vec<String> {
         .collect()
 }
 
+fn read_obj_vertices_and_faces(path: &PathBuf) -> (Vec<[f64; 3]>, Vec<[usize; 3]>) {
+    let mut vertices = Vec::new();
+    let mut faces = Vec::new();
+    for line in read_obj_lines(path) {
+        if let Some(rest) = line.strip_prefix("v ") {
+            let coordinates = rest
+                .split_whitespace()
+                .map(|value| value.parse::<f64>().expect("OBJ coordinate should parse"))
+                .collect::<Vec<_>>();
+            assert_eq!(coordinates.len(), 3);
+            vertices.push([coordinates[0], coordinates[1], coordinates[2]]);
+        } else if let Some(rest) = line.strip_prefix("f ") {
+            let indices = rest
+                .split_whitespace()
+                .map(|value| value.parse::<usize>().expect("OBJ face index should parse") - 1)
+                .collect::<Vec<_>>();
+            assert_eq!(indices.len(), 3);
+            faces.push([indices[0], indices[1], indices[2]]);
+        }
+    }
+    (vertices, faces)
+}
+
 fn inline_feature(id: &str, vertices: &str, boundaries: &str) -> Vec<u8> {
     format!(
         r#"{{"type":"CityJSONFeature","id":"{id}","transform":{{"scale":[1.0,1.0,1.0],"translate":[0.0,0.0,0.0]}},"CityObjects":{{"{id}":{{"type":"Building","geometry":[{{"type":"MultiSurface","lod":"1","boundaries":{boundaries}}}]}}}},"vertices":{vertices}}}"#
     )
     .into_bytes()
+}
+
+fn face_normal(vertices: &[[f64; 3]], face: [usize; 3]) -> [f64; 3] {
+    let p0 = vertices[face[0]];
+    let p1 = vertices[face[1]];
+    let p2 = vertices[face[2]];
+    let u = [p1[0] - p0[0], p1[1] - p0[1], p1[2] - p0[2]];
+    let v = [p2[0] - p0[0], p2[1] - p0[1], p2[2] - p0[2]];
+    [
+        u[1] * v[2] - u[2] * v[1],
+        u[2] * v[0] - u[0] * v[2],
+        u[0] * v[1] - u[1] * v[0],
+    ]
+}
+
+fn dot_f64(lhs: [f64; 3], rhs: [f64; 3]) -> f64 {
+    lhs[0] * rhs[0] + lhs[1] * rhs[1] + lhs[2] * rhs[2]
 }
 
 #[test]
@@ -132,6 +172,52 @@ fn convert_to_obj_triangulates_polygons_and_preserves_unclipped_geometry_by_defa
         2
     );
     assert!(lines.iter().any(|line| line == "v 2 2 0"));
+}
+
+#[test]
+fn convert_to_obj_preserves_winding_for_y_dominant_polygons() {
+    let input = inline_feature(
+        "y-normal-quad",
+        "[[0.0,0.0,0.0],[0.0,0.0,2.0],[2.0,0.0,2.0],[2.0,0.0,0.0]]",
+        "[[[0,1,2,3]]]",
+    );
+    let model = json::from_feature_slice(&input).expect("inline feature should parse");
+    let output_path = stable_output_path_with_suffix("convert_to_obj_y_winding", "obj");
+
+    convert_to_obj(&model, &output_path, &ObjExportOptions::default())
+        .expect("OBJ conversion should succeed");
+
+    let (vertices, faces) = read_obj_vertices_and_faces(&output_path);
+    assert_eq!(faces.len(), 2);
+    for face in faces {
+        assert!(
+            dot_f64(face_normal(&vertices, face), [0.0, 1.0, 0.0]) > 0.0,
+            "OBJ face {face:?} should preserve the source +Y winding"
+        );
+    }
+}
+
+#[test]
+fn convert_to_obj_preserves_reversed_winding_for_y_dominant_polygons() {
+    let input = inline_feature(
+        "negative-y-normal-quad",
+        "[[0.0,0.0,0.0],[2.0,0.0,0.0],[2.0,0.0,2.0],[0.0,0.0,2.0]]",
+        "[[[0,1,2,3]]]",
+    );
+    let model = json::from_feature_slice(&input).expect("inline feature should parse");
+    let output_path = stable_output_path_with_suffix("convert_to_obj_negative_y_winding", "obj");
+
+    convert_to_obj(&model, &output_path, &ObjExportOptions::default())
+        .expect("OBJ conversion should succeed");
+
+    let (vertices, faces) = read_obj_vertices_and_faces(&output_path);
+    assert_eq!(faces.len(), 2);
+    for face in faces {
+        assert!(
+            dot_f64(face_normal(&vertices, face), [0.0, -1.0, 0.0]) > 0.0,
+            "OBJ face {face:?} should preserve the source -Y winding"
+        );
+    }
 }
 
 #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -256,6 +256,7 @@ const NO_EFFECT_INFO_RULES: &[NoEffectInfoRule] = &[
     NoEffectInfoRule {
         flag: "--grid-minz",
         n_a_formats: &[
+            crate::OutputFormatKind::Obj,
             crate::OutputFormatKind::Cityjson,
             crate::OutputFormatKind::Cityjsonseq,
         ],
@@ -264,10 +265,29 @@ const NO_EFFECT_INFO_RULES: &[NoEffectInfoRule] = &[
     NoEffectInfoRule {
         flag: "--grid-maxz",
         n_a_formats: &[
+            crate::OutputFormatKind::Obj,
             crate::OutputFormatKind::Cityjson,
             crate::OutputFormatKind::Cityjsonseq,
         ],
         is_present: cli_has_grid_maxz,
+    },
+    NoEffectInfoRule {
+        flag: "--3dtiles-implicit",
+        n_a_formats: &[
+            crate::OutputFormatKind::Obj,
+            crate::OutputFormatKind::Cityjson,
+            crate::OutputFormatKind::Cityjsonseq,
+        ],
+        is_present: cli_has_3dtiles_implicit,
+    },
+    NoEffectInfoRule {
+        flag: "--3dtiles-content-clip-to-tile-bounds",
+        n_a_formats: &[
+            crate::OutputFormatKind::Obj,
+            crate::OutputFormatKind::Cityjson,
+            crate::OutputFormatKind::Cityjsonseq,
+        ],
+        is_present: cli_has_3dtiles_content_clip_to_tile_bounds,
     },
 ];
 
@@ -327,6 +347,14 @@ fn cli_has_grid_maxz(cli: &Cli) -> bool {
     cli.grid_maxz.is_some()
 }
 
+fn cli_has_3dtiles_implicit(cli: &Cli) -> bool {
+    cli.cesium3dtiles_implicit
+}
+
+fn cli_has_3dtiles_content_clip_to_tile_bounds(cli: &Cli) -> bool {
+    cli.cesium3dtiles_content_clip_to_tile_bounds
+}
+
 fn unique_output_formats(formats: &[crate::OutputFormatKind]) -> Vec<crate::OutputFormatKind> {
     let mut unique_formats = Vec::new();
     for &format in formats {
@@ -341,6 +369,7 @@ fn unique_output_formats(formats: &[crate::OutputFormatKind]) -> Vec<crate::Outp
 fn output_format_name(format: crate::OutputFormatKind) -> &'static str {
     match format {
         crate::OutputFormatKind::Cesium3dTiles => "3dtiles",
+        crate::OutputFormatKind::Obj => "obj",
         crate::OutputFormatKind::Cityjson => "cityjson",
         crate::OutputFormatKind::Cityjsonseq => "cityjsonseq",
     }
@@ -535,6 +564,16 @@ mod tests {
     }
 
     #[test]
+    fn validation_accepts_obj_format() {
+        let mut args = dataset_args();
+        args.extend(["--format".to_string(), "obj".to_string()]);
+        let cli = Cli::try_parse_from(args).unwrap();
+
+        assert_eq!(cli.format, OutputFormatKind::Obj);
+        assert!(cli.validate_parameter_combinations(&[cli.format]).is_ok());
+    }
+
+    #[test]
     fn validation_accepts_multiple_formats_directly() {
         let cli = Cli::try_parse_from(dataset_args()).unwrap();
 
@@ -585,6 +624,22 @@ mod tests {
             .no_effect_info_messages(&[OutputFormatKind::Cesium3dTiles])
             .is_empty());
         assert!(cli.validate_parameter_combinations(&[cli.format]).is_ok());
+    }
+
+    #[test]
+    fn obj_reports_3dtiles_only_flags_as_no_effect() {
+        let mut cli = Cli::try_parse_from(dataset_args()).unwrap();
+        cli.cesium3dtiles_implicit = true;
+        cli.cesium3dtiles_content_clip_to_tile_bounds = true;
+
+        assert_eq!(
+            cli.no_effect_info_messages(&[OutputFormatKind::Obj]),
+            vec![
+                "--3dtiles-implicit has no effect for selected output formats: obj".to_string(),
+                "--3dtiles-content-clip-to-tile-bounds has no effect for selected output formats: obj"
+                    .to_string(),
+            ]
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -85,6 +85,7 @@ pub enum OutputFormatKind {
     #[value(name = "3dtiles")]
     #[default]
     Cesium3dTiles,
+    Obj,
     Cityjson,
     Cityjsonseq,
 }
@@ -1334,6 +1335,7 @@ struct TileFilesPreparedOutput {
 
 enum PreparedOutput {
     Cesium3dTiles(Box<Cesium3dTilesPreparedOutput>),
+    Obj(TileFilesPreparedOutput),
     Cityjson(TileFilesPreparedOutput),
     Cityjsonseq(TileFilesPreparedOutput),
 }
@@ -1342,16 +1344,18 @@ impl PreparedOutput {
     fn source_crs(&self) -> &str {
         match self {
             PreparedOutput::Cesium3dTiles(prepared) => &prepared.source_crs,
-            PreparedOutput::Cityjson(prepared) | PreparedOutput::Cityjsonseq(prepared) => {
-                &prepared.source_crs
-            }
+            PreparedOutput::Obj(prepared)
+            | PreparedOutput::Cityjson(prepared)
+            | PreparedOutput::Cityjsonseq(prepared) => &prepared.source_crs,
         }
     }
 
     fn root_enu_frame(&self) -> Option<&RootEnuFrame> {
         match self {
             PreparedOutput::Cesium3dTiles(prepared) => Some(&prepared.root_enu_frame),
-            PreparedOutput::Cityjson(_) | PreparedOutput::Cityjsonseq(_) => None,
+            PreparedOutput::Obj(_)
+            | PreparedOutput::Cityjson(_)
+            | PreparedOutput::Cityjsonseq(_) => None,
         }
     }
 }
@@ -1628,6 +1632,70 @@ impl OutputFormatBackend for Cesium3dTilesBackend {
 
 struct CityjsonBackend;
 
+struct ObjBackend;
+
+impl OutputFormatBackend for ObjBackend {
+    fn prepare(
+        &self,
+        _cli: &crate::cli::Cli,
+        world: &parser::World,
+        quadtree: &spatial_structs::QuadTree,
+        _grid_cellsize: u32,
+        _geometric_error_factor: f64,
+        _debug_data_output_path: &Path,
+    ) -> Result<PreparedOutput, Box<dyn std::error::Error>> {
+        Ok(PreparedOutput::Obj(TileFilesPreparedOutput {
+            export_jobs: quadtree_leaf_tile_export_jobs(world, quadtree),
+            source_crs: format!("EPSG:{}", world.crs.to_epsg()?),
+        }))
+    }
+
+    fn jobs(&self, prepared: &PreparedOutput) -> Vec<TileExportJob> {
+        let PreparedOutput::Obj(prepared) = prepared else {
+            return Vec::new();
+        };
+        prepared.export_jobs.clone()
+    }
+
+    fn write_tile(
+        &self,
+        job: &TileExportJob,
+        model: &cityjson_lib::CityModel,
+        context: &TileWriteContext<'_>,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let output_file = context
+            .output_tiles_dir
+            .join(job.content_tile_coord.to_string())
+            .with_extension("obj");
+        cityjson_convert::convert_to_obj(
+            model,
+            &output_file,
+            &cityjson_convert::ObjExportOptions::default(),
+        )?;
+        Ok(())
+    }
+
+    fn finalize(
+        &self,
+        _cli: &crate::cli::Cli,
+        _quadtree: &spatial_structs::QuadTree,
+        _successful_jobs: &[TileExportJob],
+        failed_jobs: &[TileExportJob],
+        _prepared: &mut PreparedOutput,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        info!("Skipped {} failed OBJ tile outputs", failed_jobs.len());
+        Ok(())
+    }
+
+    fn write_manifest_only(
+        &self,
+        _cli: &crate::cli::Cli,
+        _prepared: &mut PreparedOutput,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        Ok(())
+    }
+}
+
 impl OutputFormatBackend for CityjsonBackend {
     fn prepare(
         &self,
@@ -1771,6 +1839,7 @@ impl OutputFormatBackend for CityjsonseqBackend {
 fn output_format_backend(kind: OutputFormatKind) -> Box<dyn OutputFormatBackend> {
     match kind {
         OutputFormatKind::Cesium3dTiles => Box::new(Cesium3dTilesBackend),
+        OutputFormatKind::Obj => Box::new(ObjBackend),
         OutputFormatKind::Cityjson => Box::new(CityjsonBackend),
         OutputFormatKind::Cityjsonseq => Box::new(CityjsonseqBackend),
     }


### PR DESCRIPTION
This implements #103, #104, #105
- [x] Move triangulation and clipping from `gltf-writer.rs` to a new file `triangle-mesh.rs`
- [x] Add obj writer with optional clipping support (based on bbox in source coordinates)
- [x] Add obj output options to cityjson-convert and Tyler programs 
- [ ] OBJ material support
- [x] the converter need to support tyler's --lod-* parameter
- [ ] if --lod-* it is not set, then write a separate OBJ file per LoD