### PR TITLE
Add support for legacy split cjseq files to cjconvert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@
 
 ### Added
 
+- `cjconvert` can now read dataset directories, including the legacy
+  `metadata.json` plus per-feature `*.city.jsonl` layout, through
+  `cityjson-index`.
 - Feature-resolution checks that verify system mode does not activate bundled
   PROJ and bundled mode does not imply native PROJ networking.
 - CityJSON color editing support, including `--color-*` selectors for CityJSON

--- a/cityjson-convert/Cargo.toml
+++ b/cityjson-convert/Cargo.toml
@@ -18,6 +18,7 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = "1.0"
+cityjson-index = { version = "0.9.0" }
 cityjson-lib = { version = "0.9.0", default-features = false }
 clap = { version = "4.6", features = ["cargo", "derive"] }
 earcutr = "0.5.0"

--- a/cityjson-convert/README.md
+++ b/cityjson-convert/README.md
@@ -119,6 +119,27 @@ cjconvert input.city.jsonl --output output/features.city.jsonl --format cityjson
 single CityJSON document is rejected because decomposing a merged document into
 feature models is not implemented.
 
+The CLI also accepts a dataset directory. This includes the legacy split
+CityJSONFeature layout with a `metadata.json` base document and one or more
+`*.city.jsonl` feature files:
+
+```text
+dataset/
+├── metadata.json
+├── feature1.city.jsonl
+└── feature2.city.jsonl
+```
+
+```shell
+cjconvert dataset --output output/model.glb --format glb
+```
+
+Directory inputs are discovered and read through `cityjson-index`. The input 
+directory is recursively scanned for CityJSONFeature files. The CLI creates or 
+refreshes the `.cityjson-index.sqlite` sidecar in the dataset
+directory. GLB, OBJ and CityJSON output merge all indexed features into one
+model in memory; CityJSONSeq preserves them as separate features.
+
 You can also customize the output:
 
 ```shell

--- a/cityjson-convert/src/main.rs
+++ b/cityjson-convert/src/main.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 use std::io::Cursor;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use anyhow::{bail, Context};
 use cityjson_convert::{
@@ -11,6 +11,8 @@ use cityjson_convert::{
 use cityjson_lib::json;
 use clap::{Parser, ValueEnum};
 use log::info;
+
+const CJINDEX_PAGE_SIZE: usize = 65_536;
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, ValueEnum)]
 #[clap(rename_all = "lower")]
@@ -25,7 +27,7 @@ enum OutputFormat {
 #[derive(Parser, Debug)]
 #[command(author, version, about)]
 struct Cli {
-    /// Input `CityJSON` file (.city.json) or CityJSONSeq/CityJSONFeature stream.
+    /// Input `CityJSON` file, `CityJSONSeq`/`CityJSONFeature` stream, or dataset directory.
     input: PathBuf,
     /// Path to the output file.
     #[arg(short, long)]
@@ -56,7 +58,7 @@ fn main() -> anyhow::Result<()> {
 
     match cli.format {
         OutputFormat::Glb => {
-            let model = json::from_file(&cli.input)?;
+            let model = read_model(&cli.input)?;
             let options = ExportOptions {
                 native_glb_color: cli.native_glb_color,
                 metadata_class_name: cli.metadata_class_name,
@@ -74,13 +76,13 @@ fn main() -> anyhow::Result<()> {
             info!("GLB written to {}", cli.output.display());
         }
         OutputFormat::Obj => {
-            let model = json::from_file(&cli.input)?;
+            let model = read_model(&cli.input)?;
             info!("Converting to OBJ");
             convert_to_obj(&model, &cli.output, &ObjExportOptions::default())?;
             info!("OBJ written to {}", cli.output.display());
         }
         OutputFormat::Cityjson => {
-            let model = json::from_file(&cli.input)?;
+            let model = read_model(&cli.input)?;
             info!("Converting to CityJSON");
             convert_to_cityjson(&model, &cli.output, &JsonExportOptions::default())?;
             info!("CityJSON written to {}", cli.output.display());
@@ -105,9 +107,22 @@ fn main() -> anyhow::Result<()> {
     Ok(())
 }
 
+fn read_model(input: &Path) -> anyhow::Result<cityjson_lib::CityModel> {
+    if !input.is_dir() {
+        return json::from_file(input).map_err(Into::into);
+    }
+
+    let (_, feature_models) = read_indexed_dataset(input)?;
+    cityjson_lib::ops::merge(feature_models).map_err(Into::into)
+}
+
 fn read_cityjsonseq_or_feature_stream(
-    input: &PathBuf,
+    input: &Path,
 ) -> anyhow::Result<(cityjson_lib::CityModel, Vec<cityjson_lib::CityModel>)> {
+    if input.is_dir() {
+        return read_indexed_dataset(input);
+    }
+
     let bytes = std::fs::read(input).with_context(|| format!("read {}", input.display()))?;
     let mut stream = serde_json::Deserializer::from_slice(&bytes).into_iter::<serde_json::Value>();
     let Some(first) = stream.next().transpose()? else {
@@ -140,4 +155,48 @@ fn read_cityjsonseq_or_feature_stream(
             Ok((base_root, feature_models))
         }
     }
+}
+
+fn read_indexed_dataset(
+    input: &Path,
+) -> anyhow::Result<(cityjson_lib::CityModel, Vec<cityjson_lib::CityModel>)> {
+    let resolved = cityjson_index::resolve_dataset(input, None)
+        .with_context(|| format!("resolve dataset {}", input.display()))?;
+    let inspection = resolved.inspect()?;
+    let mut city_index =
+        cityjson_index::CityIndex::open(resolved.storage_layout(), &resolved.index_path)?;
+    if !inspection.index.exists || inspection.index.fresh != Some(true) {
+        info!(
+            "Rebuilding cjindex sidecar at {}",
+            resolved.index_path.display()
+        );
+        city_index.reindex()?;
+    }
+
+    let metadata = city_index.metadata()?;
+    let base_document = metadata
+        .first()
+        .ok_or_else(|| anyhow::anyhow!("dataset does not contain any source metadata"))?;
+    let base_root = json::from_slice(&serde_json::to_vec(base_document.as_ref())?)?;
+    let mut feature_models = Vec::new();
+    let mut after_record_id = None;
+    loop {
+        let page =
+            city_index.package_ref_page_after_record_id(after_record_id, CJINDEX_PAGE_SIZE)?;
+        if page.is_empty() {
+            break;
+        }
+        after_record_id = page.last().map(|package| package.record_id);
+        feature_models.extend(
+            city_index
+                .read_packages(&page)?
+                .into_iter()
+                .map(|package| package.model),
+        );
+    }
+    if feature_models.is_empty() {
+        bail!("dataset does not contain any features");
+    }
+
+    Ok((base_root, feature_models))
 }

--- a/cityjson-convert/tests/gltf_writer_geometry.rs
+++ b/cityjson-convert/tests/gltf_writer_geometry.rs
@@ -25,6 +25,34 @@ fn stable_output_path_with_suffix(name: &str, suffix: &str) -> PathBuf {
         .join(format!("{name}.{suffix}"))
 }
 
+fn legacy_feature_dataset_path(name: &str) -> PathBuf {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("output")
+        .join(name);
+    if path.exists() {
+        fs::remove_dir_all(&path).expect("remove previous legacy feature dataset");
+    }
+    fs::create_dir_all(&path).expect("create legacy feature dataset");
+
+    let items = include_bytes!("data/multi_feature_types.city.jsonl")
+        .split(|byte| *byte == b'\n')
+        .filter(|item| !item.is_empty())
+        .collect::<Vec<_>>();
+    assert_eq!(items.len(), 3);
+    let mut metadata: Value =
+        serde_json::from_slice(items[0]).expect("parse dataset metadata fixture");
+    metadata["transform"]["translate"] = serde_json::json!([100.0, 200.0, 0.0]);
+    fs::write(
+        path.join("metadata.json"),
+        serde_json::to_vec(&metadata).expect("serialize dataset metadata"),
+    )
+    .expect("write dataset metadata");
+    fs::write(path.join("building.city.jsonl"), items[1]).expect("write building feature");
+    fs::write(path.join("water.city.jsonl"), items[2]).expect("write water feature");
+    path
+}
+
 fn read_glb_json(bytes: &[u8]) -> Value {
     assert!(
         bytes.len() >= 20,
@@ -365,6 +393,59 @@ fn cjconvert_can_write_cityjson_cityjsonseq_and_obj() {
     assert!(obj_lines.iter().any(|line| line.starts_with("o ")));
     assert!(obj_lines.iter().any(|line| line.starts_with("v ")));
     assert!(obj_lines.iter().any(|line| line.starts_with("f ")));
+}
+
+#[test]
+fn cjconvert_supports_legacy_feature_file_datasets() {
+    let dataset = legacy_feature_dataset_path("cjconvert_legacy_feature_dataset");
+    let cityjson_output = stable_output_path_with_suffix("cjconvert_legacy", "city.json");
+    let cityjsonseq_output = stable_output_path_with_suffix("cjconvert_legacy", "city.jsonl");
+    let obj_output = stable_output_path_with_suffix("cjconvert_legacy", "obj");
+    let glb_output = stable_output_path("cjconvert_legacy");
+
+    for (format, output) in [
+        ("cityjson", &cityjson_output),
+        ("cityjsonseq", &cityjsonseq_output),
+        ("obj", &obj_output),
+        ("glb", &glb_output),
+    ] {
+        let status = Command::new(env!("CARGO_BIN_EXE_cjconvert"))
+            .arg(&dataset)
+            .arg("--output")
+            .arg(output)
+            .arg("--format")
+            .arg(format)
+            .status()
+            .unwrap_or_else(|error| panic!("run cjconvert {format}: {error}"));
+        assert!(status.success(), "cjconvert {format} should succeed");
+    }
+
+    assert!(dataset.join(".cityjson-index.sqlite").is_file());
+
+    let cityjson: Value = serde_json::from_slice(
+        &fs::read(&cityjson_output).expect("read legacy dataset CityJSON output"),
+    )
+    .expect("parse legacy dataset CityJSON output");
+    assert_eq!(cityjson["type"], "CityJSON");
+    assert!(cityjson["CityObjects"].get("building-feature").is_some());
+    assert!(cityjson["CityObjects"].get("water-feature").is_some());
+
+    let sequence = read_json_lines(&cityjsonseq_output);
+    assert_eq!(sequence.len(), 3);
+    assert_eq!(sequence[0]["type"], "CityJSON");
+    assert_eq!(sequence[1]["type"], "CityJSONFeature");
+    assert_eq!(sequence[2]["type"], "CityJSONFeature");
+
+    let obj = read_obj_lines(&obj_output);
+    assert!(obj.iter().any(|line| line == "o building-feature"));
+    assert!(obj.iter().any(|line| line == "o water-feature"));
+    assert!(obj.iter().any(|line| line == "v 100 200 0"));
+
+    let glb = fs::read(&glb_output).expect("read legacy dataset GLB output");
+    let glb_json = read_glb_json(&glb);
+    assert!(glb_json["meshes"]
+        .as_array()
+        .is_some_and(|meshes| !meshes.is_empty()));
 }
 
 #[allow(clippy::cast_possible_truncation)]


### PR DESCRIPTION
This adds support for the legacy split cjseq files to the cjconvert program. I figured this is handy to have to work with older datasets, and while we convert pipelines away from the legacy format.